### PR TITLE
Rename illegal class and style

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -105,7 +105,8 @@ header h1 {
   margin: 0.3rem 0 1rem 0;
 }
 
-.local-time-checkbox {
+.local-time-checkbox,
+.twelve_hour_time-checkbox {
   float: right;
 }
 
@@ -114,7 +115,7 @@ input[type=checkbox] ~ label {
   border: 2px solid red;
   border-radius: 1rem;
   padding: 0.2rem 0.4rem;
-  margin-bottom: 0.2rem;
+  margin: 0 0.1rem 0.2rem 0;
   color: red;
   font-size: smaller;
   text-decoration: line-through;
@@ -138,6 +139,7 @@ input.selection-control {
 
 .program-container {
   margin-top: 0.5rem;
+  clear:both;
 }
 
 .date-heading {

--- a/src/components/FilterableProgram.js
+++ b/src/components/FilterableProgram.js
@@ -11,7 +11,7 @@ const FilterableProgram = ({ program, locations, tags, offset, handler }) => {
   const [showLocalTime, setShowLocalTime] = useState(
     storedLocalTime === "false" ? false : true
   );
-  const stored12HourTime = localStorage.getItem("12_hour_time");
+  const stored12HourTime = localStorage.getItem("twelve_hour_time");
   const [show12HourTime, setShow12HourTime] = useState(
     stored12HourTime === configData.TIME_FORMAT.DEFAULT_12HR
       ? "false" // If defaulting to 12 hour, assume true unless "false" saved.
@@ -45,15 +45,15 @@ const FilterableProgram = ({ program, locations, tags, offset, handler }) => {
     );
 
   const show12HourTimeCheckbox = configData.TIME_FORMAT.SHOW_CHECKBOX ? (
-    <div className="12_hour_time-checkbox">
+    <div className="twelve_hour_time-checkbox">
       <input
-        id="12_hour_time"
-        name="12_hour_time"
+        id="twelve_hour_time"
+        name="twelve_hour_time"
         type="checkbox"
         checked={show12HourTime}
         onChange={handleShow12HourTime}
       />
-      <label htmlFor="12_hour_time">
+      <label htmlFor="twelve_hour_time">
         {configData.TIME_FORMAT.CHECKBOX_LABEL}
       </label>
     </div>


### PR DESCRIPTION
Push the new button/checkbox right.  They're starting to take up some space and maybe should be made into more of a toggle, possibly from the React side.

Note that CSS classes can't start with numbers, so I renamed it, hopefully correctly---but not the storage key, which you may want to change, too, for consistency.