### PR TITLE
Optionally put Grenadine format into tags as "type", and document

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The main place customisations go is the `src/config.json` file. Settings current
 * `NAVIGATION.INFO`: Label for the Information menu link.
 * `NAVIGATION.EXTRA`: An array of extra menu links. Each entry should take the form: `{ "LABEL": "Octocon Home", "URL": "https://octocon.com" }`. To have no extra links, set to `"EXTRA": []` or delete `EXTRA` entry altogether.
 * `TAGS.SEPARATE`: An array of tag prefixes to separate into individual drop-downs. Tags should be specified as follows: `{ "PREFIX": "type", "PLACEHOLDER": "Select type" }`.
+* `TAGS.FORMAT_AS_TAG`: If set to true, turns Grenadine item format into a KonOpas-style "type" tag.
 * `LINKS.MEETING`: Text to display on meeting links.
 * `LINKS.RECORDING`: Text to display on recording links.
 * `LOCAL_TIME.CHECKBOX_LABEL`: Label for the "Show Local Time" checkbox.
@@ -70,6 +71,9 @@ The main place customisations go is the `src/config.json` file. Settings current
 * `TIME_FORMAT.DEFAULT_12HR`: Set to true if you want time displayed in 12 hour format by default.
 * `TIME_FORMAT.SHOW_CHECKBOX`: If set to false, users will not be given option to change between 12 and 24 hour time.
 * `TIME_FORMAT.CHECKBOX_LABEL`: Label for the 12 hour time checkbox label.
+* `SHOW_PAST_ITEMS.DEFAULT`: Set to true to show past programme items by default.
+* `SHOW_PAST_ITEMS.CHECKBOX_LABEL`: Label for the show past items checkbox.
+* `SHOW_PAST_ITEMS.ADJUST_MINUTES`: Some wiggle room (in minutes) in order not to hide past items immediately they start.
 * `PEOPLE.THUMBNAILS.SHOW_THUMBNAILS`: Set to false to not show member thumbnails (useful to remove spurious controls if pictures not in file).
 * `PEOPLE.THUMBNAILS.SHOW_CHECKBOX`: Set to false to hide "Show thumbnails" checkbox.
 * `PEOPLE.THUMBNAILS.CHECKBOX_LABEL`: Label for "Show thumbnails" checkbox.

--- a/src/ProgramData.js
+++ b/src/ProgramData.js
@@ -93,8 +93,19 @@ export class ProgramData {
     return locations;
   }
 
+	static reformatAsTag(program) {
+		//Grenadine does not have a mode to put types ("format") into the tags like Zambia does.
+		for (let item of program) {
+			if (item.format && item.hasOwnProperty("tags"))
+				item.tags.push("type:" + item.format);
+		}
+		return program;
+	}
+
   // Extract tags from program.
   static processTags(program) {
+		//Pre-parse grenadine Format as konopas Type.
+
     // Tags is an object with a property for each tag type. Default to one property for general tags.
     const tags = { tags: [] };
 
@@ -150,7 +161,9 @@ export class ProgramData {
 
   // Process data from program and people.
   static processData(progData, pplData) {
-    const program = this.processProgramData(progData);
+    let program = this.processProgramData(progData);
+		if (configData.TAGS.FORMAT_AS_TAG) 
+			program = this.reformatAsTag(program);
     const people = this.processPeopleData(pplData);
     this.addProgramParticipantDetails(program, people);
     const locations = this.processLocations(program);

--- a/src/components/FilterableProgram.js
+++ b/src/components/FilterableProgram.js
@@ -138,14 +138,15 @@ const FilterableProgram = () => {
         });
       }
     }
-		if (!showPastItems) {
-			// Filter by past item state.  Quick hack to treat this as a filter.
-			const now = LocalTime.dateToConTime(new Date());
-			console.log("Showing items after", now.date, now.time, "(adjusted con time).");
-			filtered = filtered.filter((item) => {
-				return (now.date < item.date) || (now.date == item.date && now.time <= item.time);
-			});
-		}
+    if (!showPastItems) {
+      // Filter by past item state.  Quick hack to treat this as a filter.
+      const now = LocalTime.dateToConTime(new Date());
+      console.log("Showing items after", now.date, now.time, "(adjusted con time).");
+      filtered = filtered.filter((item) => {
+        // eslint-disable-next-line
+        return (now.date < item.date) || (now.date === item.date && now.time <= item.time);
+      });
+    }
     return filtered;
   }
 

--- a/src/config.json
+++ b/src/config.json
@@ -16,7 +16,8 @@
     "SEPARATE": [
       { "PREFIX": "type", "PLACEHOLDER": "Select type" },
       { "PREFIX": "test", "PLACEHOLDER": "Select test" }
-    ]
+    ],
+    "FORMAT_AS_TAG": false
   },
   "EXPAND": {
     "EXPAND_ALL_LABEL": "Expand All",


### PR DESCRIPTION
This handles item types as they appear in the Grenadine data, using a config setting.  I also documented the show past items config while I was in the README.  You can see the results at schedule.boskone.org (though it looks just like it had  been konopas data).