### PR TITLE
Add past item logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ See the section about [React app deployment](https://facebook.github.io/create-r
 The main place customisations go is the `src/config.json` file. Settings currently available include:
 
 * `BASE_PATH`: The path to ConClár within your webserver. Set to '/' to run in the root directory. See below for running in a subdirectory.
+* `APP_ID`: A unique id to distinguish between instances of multi-year conventions.
 * `APP_TITLE`: The title to appear at the top of the webpage, and in the browser window title.
 * `PROGRAM_DATA_URL`: The address of the file containing programme data.
 * `PEOPLE_DATA_URL`: The address of the file listing people. If these are the same, both will be read from one file, but programme data must come before people data.
@@ -71,9 +72,9 @@ The main place customisations go is the `src/config.json` file. Settings current
 * `TIME_FORMAT.DEFAULT_12HR`: Set to true if you want time displayed in 12 hour format by default.
 * `TIME_FORMAT.SHOW_CHECKBOX`: If set to false, users will not be given option to change between 12 and 24 hour time.
 * `TIME_FORMAT.CHECKBOX_LABEL`: Label for the 12 hour time checkbox label.
-* `SHOW_PAST_ITEMS.DEFAULT`: Set to true to show past programme items by default.
+* `SHOW_PAST_ITEMS.SHOW_CHECKBOX`: Set to true to show the option during the convention; otherwise past programme items are shown by default.
 * `SHOW_PAST_ITEMS.CHECKBOX_LABEL`: Label for the show past items checkbox.
-* `SHOW_PAST_ITEMS.ADJUST_MINUTES`: Some wiggle room (in minutes) in order not to hide past items immediately they start.
+* `SHOW_PAST_ITEMS.ADJUST_MINUTES`: Some wiggle room (in minutes) in order not to hide past items immediately as they start.
 * `PEOPLE.THUMBNAILS.SHOW_THUMBNAILS`: Set to false to not show member thumbnails (useful to remove spurious controls if pictures not in file).
 * `PEOPLE.THUMBNAILS.SHOW_CHECKBOX`: Set to false to hide "Show thumbnails" checkbox.
 * `PEOPLE.THUMBNAILS.CHECKBOX_LABEL`: Label for "Show thumbnails" checkbox.

--- a/src/components/FilterableProgram.js
+++ b/src/components/FilterableProgram.js
@@ -38,8 +38,6 @@ const FilterableProgram = () => {
   const total = filtered.length;
   const totalMessage = `Listing ${total} items`;
 
-  const duringCon = program && program.length ? LocalTime.inConTime(program) : false;
-
   const localTimeCheckbox =
     offset === null || offset === 0 ? (
       ""
@@ -76,7 +74,7 @@ const FilterableProgram = () => {
   );
 
   //Nice to have a check here for whether it's during con right now.
-  const pastItemsCheckbox = duringCon && configData.SHOW_PAST_ITEMS.SHOW_CHECKBOX ? ( 
+  const pastItemsCheckbox = isDuringCon(program) && configData.SHOW_PAST_ITEMS.SHOW_CHECKBOX ? ( 
     <div className="past-items-checkbox">
       <input
         id={LocalTime.pastItemsClass}
@@ -95,8 +93,6 @@ const FilterableProgram = () => {
 
   function applyFilters(program) {
     const term = search.trim().toLowerCase();
-
-    const duringCon = program && program.length ? LocalTime.inConTime(program) : false;
 
     // If no filters, return full program;
     if (term.length === 0 && selLoc.length === 0 && selTags === 0)
@@ -142,7 +138,7 @@ const FilterableProgram = () => {
         });
       }
     }
-    if (duringCon && !showPastItems) {
+    if (isDuringCon(program) && !showPastItems) {
       // Filter by past item state.  Quick hack to treat this as a filter.
       const now = LocalTime.dateToConTime(new Date());
       //console.log("Showing items after", now.date, now.time, "(adjusted con time).");
@@ -152,6 +148,10 @@ const FilterableProgram = () => {
       });
     }
     return filtered;
+  }
+
+  function isDuringCon(program) {
+    return program && program.length ? LocalTime.inConTime(program) : false;
   }
 
   function handleSearch(event) {

--- a/src/components/FilterableProgram.js
+++ b/src/components/FilterableProgram.js
@@ -38,6 +38,8 @@ const FilterableProgram = () => {
   const total = filtered.length;
   const totalMessage = `Listing ${total} items`;
 
+  const duringCon = program && program.length ? LocalTime.inConTime(program) : false;
+
   const localTimeCheckbox =
     offset === null || offset === 0 ? (
       ""
@@ -74,7 +76,7 @@ const FilterableProgram = () => {
   );
 
   //Nice to have a check here for whether it's during con right now.
-  const pastItemsCheckbox = true ? ( 
+  const pastItemsCheckbox = duringCon && configData.SHOW_PAST_ITEMS.SHOW_CHECKBOX ? ( 
     <div className="past-items-checkbox">
       <input
         id={LocalTime.pastItemsClass}
@@ -93,6 +95,8 @@ const FilterableProgram = () => {
 
   function applyFilters(program) {
     const term = search.trim().toLowerCase();
+
+    const duringCon = program && program.length ? LocalTime.inConTime(program) : false;
 
     // If no filters, return full program;
     if (term.length === 0 && selLoc.length === 0 && selTags === 0)
@@ -138,10 +142,10 @@ const FilterableProgram = () => {
         });
       }
     }
-    if (!showPastItems) {
+    if (duringCon && !showPastItems) {
       // Filter by past item state.  Quick hack to treat this as a filter.
       const now = LocalTime.dateToConTime(new Date());
-      console.log("Showing items after", now.date, now.time, "(adjusted con time).");
+      //console.log("Showing items after", now.date, now.time, "(adjusted con time).");
       filtered = filtered.filter((item) => {
         // eslint-disable-next-line
         return (now.date < item.date) || (now.date === item.date && now.time <= item.time);

--- a/src/config.json
+++ b/src/config.json
@@ -2,9 +2,9 @@
   "BASE_PATH": "/",
   "APP_ID": "O2021",
   "APP_TITLE": "ConClár Programme Guide",
-  "PROGRAM_DATA_URL": "https://zambia.octocon.com/konOpasData.jsonp",
-  "PEOPLE_DATA_URL": "https://zambia.octocon.com/konOpasData.jsonp",
-  "TIMEZONE": "Europe/Dublin",
+  "PROGRAM_DATA_URL": "//test.mcdemarco.net/data/konOpasData.jsonp",
+  "PEOPLE_DATA_URL": "//test.mcdemarco.net/data/konOpasData.jsonp",
+  "TIMEZONE": "Europe/Moscow",
   "NAVIGATION": {
     "PROGRAM": "Programme",
     "PEOPLE": "People",
@@ -40,7 +40,7 @@
     "CHECKBOX_LABEL": "Show 12 hour time"
   },
   "SHOW_PAST_ITEMS": {
-    "DEFAULT": true,
+    "SHOW_CHECKBOX": true,
     "CHECKBOX_LABEL": "Show past items",
     "ADJUST_MINUTES": 10
   },

--- a/src/config.json
+++ b/src/config.json
@@ -2,9 +2,9 @@
   "BASE_PATH": "/",
   "APP_ID": "O2021",
   "APP_TITLE": "ConClár Programme Guide",
-  "PROGRAM_DATA_URL": "//test.mcdemarco.net/data/konOpasData.jsonp",
-  "PEOPLE_DATA_URL": "//test.mcdemarco.net/data/konOpasData.jsonp",
-  "TIMEZONE": "Europe/Moscow",
+  "PROGRAM_DATA_URL": "https://zambia.octocon.com/konOpasData.jsonp",
+  "PEOPLE_DATA_URL": "https://zambia.octocon.com/konOpasData.jsonp",
+  "TIMEZONE": "Europe/Dublin",
   "NAVIGATION": {
     "PROGRAM": "Programme",
     "PEOPLE": "People",

--- a/src/model.js
+++ b/src/model.js
@@ -94,6 +94,7 @@ const model = {
     );
     ProgramSelection.setAllSelections(state.mySelections);
   }),
+
   // Computed.
   isSelected: computed((state) => {
     return (id) => state.mySelections.find((item) => item === id) || false;

--- a/src/utils/LocalTime.js
+++ b/src/utils/LocalTime.js
@@ -196,6 +196,7 @@ export class LocalTime {
 
   static dateToConTime(datetime) {
     //SO: https://stackoverflow.com/a/53652131
+		//datetime is a javascript Date object
 
     let invdate = new Date(datetime.toLocaleString('en-US', {
       timeZone: configData.TIMEZONE
@@ -215,5 +216,18 @@ export class LocalTime {
     
     return conTimeFormatted;
   }
+
+	static inConTime(program) {
+		//Expects the program items to have dates.
+		const today = new Date();
+		const aDay = 3600 * 1000 * 24; //in  milliseconds
+		const firstItem = program[0];
+		const lastItem = program[program.length - 1];
+		//Pad by one day to avoid time zone issues.
+		const tomorrow = this.dateToConTime(new Date(Date.now(today) + aDay));
+		const yesterday = this.dateToConTime(new Date(Date.now(today) - aDay));
+		//Neither the first day of con is after tomorrow nor the last day of con is before yesterday.
+		return !(firstItem.date > tomorrow.date || lastItem.date < yesterday.date)
+	}
 
 }


### PR DESCRIPTION
This hides the Show Past Items button when the con is too far in the past or future for it to matter.