### PR TITLE
Make multiselect searching configurable, and add plain tag config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ The main place customisations go is the `src/config.json` file. Settings current
 * `NAVIGATION.MYSCHEDULE`: Label for user's personal schedule.
 * `NAVIGATION.INFO`: Label for the Information menu link.
 * `NAVIGATION.EXTRA`: An array of extra menu links. Each entry should take the form: `{ "LABEL": "Octocon Home", "URL": "https://octocon.com" }`. To have no extra links, set to `"EXTRA": []` or delete `EXTRA` entry altogether.
+* `LOCATIONS.SEARCHABLE`: Whether the location list can be searched by typing.  (Searching can be inconvenient on touch screens.)
+* `TAGS.PLACEHOLDER`: The placeholder when selecting tags (unless separated).
+* `TAGS.SEARCHABLE`: Whether the tag list can be searched by typing (unless separated).
 * `TAGS.SEPARATE`: An array of tag prefixes to separate into individual drop-downs. Tags should be specified as follows: `{ "PREFIX": "type", "PLACEHOLDER": "Select type" }`.
 * `TAGS.FORMAT_AS_TAG`: If set to true, turns Grenadine item format into a KonOpas-style "type" tag.
 * `LINKS.MEETING`: Text to display on meeting links.

--- a/src/components/FilterableProgram.js
+++ b/src/components/FilterableProgram.js
@@ -191,13 +191,15 @@ const FilterableProgram = () => {
     });
     // Only add drop-down if tag type actually contains elements.
     if (tags[tag].length) {
-      const placeholder = tagData ? tagData.PLACEHOLDER : "Select tags";
+      const placeholder = tagData ? tagData.PLACEHOLDER : configData.TAGS.PLACEHOLDER;
+      const searchable = tagData ? tagData.SEARCHABLE : configData.TAGS.SEARCHABLE;
       tagFilters.push(
         <div key={tag} className={"filter-tags filter-tags-" + tag}>
           <ReactSelect
             placeholder={placeholder}
             options={tags[tag]}
             isMulti
+            isSearchable={searchable}
             value={selTags[tag]}
             onChange={(value) => handleTags(tag, value)}
           />
@@ -214,6 +216,7 @@ const FilterableProgram = () => {
             placeholder="Select locations"
             options={locations}
             isMulti
+            isSearchable={configData.LOCATIONS.SEARCHABLE}
             value={selLoc}
             onChange={handleLoc}
           />

--- a/src/config.json
+++ b/src/config.json
@@ -12,10 +12,15 @@
     "INFO": "Information",
     "EXTRA": [{ "LABEL": "Octocon Home", "URL": "https://octocon.com" }]
   },
+  "LOCATIONS": {
+    "SEARCHABLE": true
+  },
   "TAGS": {
+    "PLACEHOLDER": "Select tags",
+    "SEARCHABLE": true,
     "SEPARATE": [
-      { "PREFIX": "type", "PLACEHOLDER": "Select type" },
-      { "PREFIX": "test", "PLACEHOLDER": "Select test" }
+      { "PREFIX": "type", "PLACEHOLDER": "Select type", "SEARCHABLE": true },
+      { "PREFIX": "test", "PLACEHOLDER": "Select test", "SEARCHABLE": true }
     ],
     "FORMAT_AS_TAG": false
   },


### PR DESCRIPTION
Config settings and code to turn off searching in multiselects (see [my bug](https://github.com/mcdemarco/conclar/issues/6) for reasons), and also to include tag configuration for when they aren't split.