### PR TITLE
Move duration inline

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -174,7 +174,7 @@ div.switch-wrapper ~ div {
 }
 
 input.switch:empty {
-  margin-left: -999px;
+  display:none;
 }
 
 input.switch:empty ~ label {
@@ -314,9 +314,17 @@ input.switch:checked ~ label:after {
   color: var(--program-tags-fg);
 }
 
-.item-tag {
+.item-tag,
+.item-location {
   display: inline-block;
   margin-right: 0.5rem;
+}
+
+/* To put duration on its own line, remove this bit. */
+.item-duration {
+  display: inline-block;
+  margin-right: 0.5rem;
+  white-space:nowrap;
 }
 
 .item-people {

--- a/src/components/ProgramItem.js
+++ b/src/components/ProgramItem.js
@@ -88,8 +88,10 @@ const ProgramItem = ({ item }) => {
       </div>
       <div className="item-entry" onClick={toggleExpanded}>
         <div className="item-title">{item.title}</div>
-        <div className="item-location">{locations}</div>
-        {duration}
+        <div className="item-line2">
+          <div className="item-location">{locations}</div>
+          {duration}
+        </div>
         <div
           className={
             expanded ? "item-details item-details-expanded" : "item-details"


### PR DESCRIPTION
These changes are necessary to move durations inline with location.  The css also actively does so, but you can comment out that class section to not do so.

For Boskone I'm also configuring the label like this:

```
"DURATION_LABEL": " (@mins mins)"
```

That's not in this PR, but I'm mentioning it in case you like it and want to make it the default.