### PR TITLE
Don't pass Invalid Date to the UI

### DIFF
--- a/src/utils/LocalTime.js
+++ b/src/utils/LocalTime.js
@@ -53,6 +53,8 @@ export class LocalTime {
     let language = window.navigator.userLanguage || window.navigator.language;
     // Assume UTC timezone for purpose of formatting date headings.
     let dateTime = new Date(date + "T00:00:00.000Z");
+		if (isNaN(dateTime.getTime()))
+			return "";
     return dateTime.toLocaleDateString(language, {
       weekday: "long",
       year: "numeric",


### PR DESCRIPTION
When Grenadine passes items without dates, they get partly processed into an "Invalid Date" day in the schedule (with no items).  The string is just more Date object jankiness, not an intentional error message.  This change removes that string, but doesn't otherwise affect processing.