### PR TITLE
Restore Zambia-style moderators and add Grenadine-style moderators

### DIFF
--- a/src/ProgramData.js
+++ b/src/ProgramData.js
@@ -52,6 +52,10 @@ export class ProgramData {
           let fullPerson = people.find(
             (fullPerson) => fullPerson.id === item.people[index].id
           );
+          //Moderator check before nuking the item person data.
+          if (item.people[index].name.indexOf("(moderator)") > 0 || 
+              (item.people[index].hasOwnProperty("role") && item.people[index].role === "Moderator"))
+            item.moderator = item.people[index].id;
           if (fullPerson) {
             // Replace partial person with full person reference.
             item.people[index] = fullPerson;

--- a/src/components/Participant.js
+++ b/src/components/Participant.js
@@ -2,7 +2,7 @@ import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 import configData from "../config.json";
 
-const Participant = ({ person, thumbnails }) => {
+const Participant = ({ person, thumbnails, moderator }) => {
   function getParticipantThumbnail(person) {
     if (thumbnails) {
       if (person.img) {
@@ -32,13 +32,25 @@ const Participant = ({ person, thumbnails }) => {
     return "";
   }
 
+  function getParticipantName(person, moderator) {
+    if (moderator) {
+      return (
+	<span>{person.name} <span className="moderator">(moderator)</span></span>
+      )
+    } else {
+      return (
+        <span>{person.name}</span>
+      )
+    }
+  }
+
   function getParticipant(person) {
     if (configData.INTERACTIVE) {
       return (
         <li className="participant">
           <Link to={"/people/" + person.id}>
             {getParticipantThumbnail(person)}
-            <span>{person.name}</span>
+            {getParticipantName(person,moderator)}
           </Link>
         </li>
       )
@@ -46,7 +58,7 @@ const Participant = ({ person, thumbnails }) => {
     return (
       <li className="participant">
         {getParticipantThumbnail(person)}
-        <span>{person.name}</span>
+        {getParticipantName(person,moderator)}
       </li>
     );
   }

--- a/src/components/ProgramItem.js
+++ b/src/components/ProgramItem.js
@@ -20,10 +20,10 @@ const ProgramItem = ({ item }) => {
   }));
 
   function toggleExpanded() {
-		if (configData.INTERACTIVE) {
-			if (expanded) collapseItem(item.id);
-			else expandItem(item.id);
-		}
+    if (configData.INTERACTIVE) {
+      if (expanded) collapseItem(item.id);
+      else expandItem(item.id);
+    }
   }
 
   function handleSelected(event) {
@@ -47,7 +47,7 @@ const ProgramItem = ({ item }) => {
   const people = [];
   if (item.people) {
     item.people.forEach((person) => {
-      people.push(<Participant key={person.id} person={person} />);
+      people.push(<Participant key={person.id} person={person} moderator={person.id === item.moderator} />);
     });
   }
   const safeDesc = DOMPurify.sanitize(item.desc);


### PR DESCRIPTION
This information was lost in the unification of persons.  I added it back on as an attribute of `item` with the appropriate person's `id`, which is then passed into Participant at the appropriate time(s) as a boolean prop.

I considered customizing the moderator text and handling other Grenadine roles, but since "moderator" is the only Zambia role and is extremely hard-coded, I did not put in any effort in that direction.  Maybe if Zambia gets more flexible this code could be expanded.