### PR TITLE
Allow configuration of DOMPurify options

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The main place customisations go is the `src/config.json` file. Settings current
 - `PEOPLE.SORT.CHECKBOX_LABEL`: Label for "Sort by full name" checkbox.
 - `PEOPLE.SEARCH.SHOW_SEARCH`: Set to false to hide "people" search box.
 - `PEOPLE.SEARCH.SEARCH_LABEL`: Label for "people2 search box.
-- `PEOPLE.BIO.PURIFY_OPTIONS"`: Pass additional options to DOMPurify when processing participant bios.  For more details, see `ITEM_DESCRIPTION.PURIFY_OPTIONS` above.
+- `PEOPLE.BIO.PURIFY_OPTIONS`: Pass additional options to DOMPurify when processing participant bios.  For more details, see `ITEM_DESCRIPTION.PURIFY_OPTIONS` above.
 - `USELESS_CHECKBOX.CHECKBOX_LABEL`: Label for any useless checkboxes.
 - `INFORMATION.MARKDOWN_URL`: The address of the markdown file containing additional information about the convention.
 - `INFORMATION.LOADING_MESSAGE`: Text to show while Markdown file is loading (usually never seen).

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The main place customisations go is the `src/config.json` file. Settings current
 - `PERMALINK.PERMALINK_TITLE`: "Title" text displayed when mouse is hovered over permalink icon.
 - `EXPAND.EXPAND_ALL_LABEL`: Label text for Expand All button.
 - `EXPAND.COLLAPSE_ALL_LABEL`: Label for Collapse All button.
+- `ITEM_DESCRIPTION.PURIFY_OPTIONS`: Pass additional options to DOMPurify when processing item descriptions.  For the available options, see [the DOMPurify documentation](https://github.com/cure53/DOMPurify#can-i-configure-dompurify).  Format options as JSON, *e.g.*, `{"FORBID_ATTR": ["style"]}`.
 - `LINKS.MEETING`: Text to display on meeting links.
 - `LINKS.RECORDING`: Text to display on recording links.
 - `LOCAL_TIME.CHECKBOX_LABEL`: Label for the "Show Local Time" checkbox.
@@ -93,6 +94,7 @@ The main place customisations go is the `src/config.json` file. Settings current
 - `PEOPLE.SORT.CHECKBOX_LABEL`: Label for "Sort by full name" checkbox.
 - `PEOPLE.SEARCH.SHOW_SEARCH`: Set to false to hide "people" search box.
 - `PEOPLE.SEARCH.SEARCH_LABEL`: Label for "people2 search box.
+- `PEOPLE.BIO.PURIFY_OPTIONS"`: Pass additional options to DOMPurify when processing participant bios.  For more details, see `ITEM_DESCRIPTION.PURIFY_OPTIONS` above.
 - `USELESS_CHECKBOX.CHECKBOX_LABEL`: Label for any useless checkboxes.
 - `INFORMATION.MARKDOWN_URL`: The address of the markdown file containing additional information about the convention.
 - `INFORMATION.LOADING_MESSAGE`: Text to show while Markdown file is loading (usually never seen).

--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -22,7 +22,7 @@ const Person = () => {
     ) : (
       ""
     );
-  const safeBio = person.bio ? DOMPurify.sanitize(person.bio, JSON.parse(JSON.stringify(configData.PEOPLE.BIO.PURIFY_OPTIONS))) : "";
+  const safeBio = person.bio ? DOMPurify.sanitize(person.bio, configData.PEOPLE.BIO.PURIFY_OPTIONS) : "";
   return (
     <div className="person">
       <h2 className="person-name">

--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -22,7 +22,7 @@ const Person = () => {
     ) : (
       ""
     );
-  const safeBio = person.bio ? DOMPurify.sanitize(person.bio) : "";
+  const safeBio = person.bio ? DOMPurify.sanitize(person.bio, JSON.parse(JSON.stringify(configData.PEOPLE.BIO.PURIFY_OPTIONS))) : "";
   return (
     <div className="person">
       <h2 className="person-name">

--- a/src/components/ProgramItem.js
+++ b/src/components/ProgramItem.js
@@ -68,7 +68,7 @@ const ProgramItem = ({ item, forceExpanded }) => {
       );
     });
   }
-  const safeDesc = DOMPurify.sanitize(item.desc);
+  const safeDesc = DOMPurify.sanitize(item.desc, JSON.parse(JSON.stringify(configData.ITEM_DESCRIPTION.PURIFY_OPTIONS)));
   const signupLink =
     item.links && item.links.signup && item.links.signup.length ? (
       <div className="item-links-signup">

--- a/src/components/ProgramItem.js
+++ b/src/components/ProgramItem.js
@@ -68,7 +68,7 @@ const ProgramItem = ({ item, forceExpanded }) => {
       );
     });
   }
-  const safeDesc = DOMPurify.sanitize(item.desc, JSON.parse(JSON.stringify(configData.ITEM_DESCRIPTION.PURIFY_OPTIONS)));
+  const safeDesc = DOMPurify.sanitize(item.desc, configData.ITEM_DESCRIPTION.PURIFY_OPTIONS);
   const signupLink =
     item.links && item.links.signup && item.links.signup.length ? (
       <div className="item-links-signup">

--- a/src/config.json
+++ b/src/config.json
@@ -34,9 +34,7 @@
     "COLLAPSE_ALL_LABEL": "Collapse All"
   },
   "ITEM_DESCRIPTION": {
-    "PURIFY_OPTIONS": {
-      "FORBID_ATTR": ["style"]
-    }
+    "PURIFY_OPTIONS": {}
   },
   "LINKS": {
     "SIGNUP": "Click to sign up",

--- a/src/config.json
+++ b/src/config.json
@@ -33,6 +33,11 @@
     "EXPAND_ALL_LABEL": "Expand All",
     "COLLAPSE_ALL_LABEL": "Collapse All"
   },
+  "ITEM_DESCRIPTION": {
+    "PURIFY_OPTIONS": {
+      "FORBID_ATTR": ["style"]
+    }
+  },
   "LINKS": {
     "SIGNUP": "Click to sign up",
     "MEETING": "Click to view stream",
@@ -77,7 +82,10 @@
       "SHOW_SEARCH": true,
       "SEARCH_LABEL": "Search people"
     },
-    "PERSON_HEADER": "Person: "
+    "PERSON_HEADER": "Person: ",
+    "BIO": {
+      "PURIFY_OPTIONS": {}
+    }
   },
   "USELESS_CHECKBOX": {
     "CHECKBOX_LABEL": "Useless checkbox"


### PR DESCRIPTION
This code passes in DOMPurify options from the config file.  Different values are supported for item descriptions and bios (the only places DOMPurify is currently used).  This handles an issue Boskone is having with some data cut and pasted into Grenadine, by using "FORBID_ATTR": ["style"] on descriptions.  I think there's also a use case for editing out more intentional bits of the source data, like unusual but technically "safe" HTML in bios.  

Documented in the readme.
