### PR TITLE
Fix for linking IDs with Grenadine data where IDs are not strings

### DIFF
--- a/src/components/ItemById.js
+++ b/src/components/ItemById.js
@@ -6,7 +6,7 @@ const ItemById = () => {
   const params = useParams();
   const program = useStoreState((state) => state.program);
   if (program.length === 0) return <></>;
-  const filteredProgram = program.filter((item) => item.id === params.id);
+  const filteredProgram = program.filter((item) => item.id.toString() === params.id);
   return <ProgramList program={filteredProgram} forceExpanded={true} />;
 };
 


### PR DESCRIPTION
A small fix to make item linking work with Grenadine data, where IDs are integers.  There's already similar code in Person.js for participant linking.