### PR TITLE
Fix for "error" returned when hitting index.html directly

### DIFF
--- a/src/components/AppRoutes.js
+++ b/src/components/AppRoutes.js
@@ -27,6 +27,7 @@ const TheApp = configData.INTERACTIVE ? (
     <Routes>
       <Route path="/">
         <Route index element={<FilterableProgram />} />
+	<Route path="/index.html" element={<FilterableProgram />} />
         <Route path="id/:id" element={<ItemById />} />
         <Route path="people">
           <Route index element={<People />} />
@@ -45,6 +46,7 @@ const TheApp = configData.INTERACTIVE ? (
     <Routes>
       <Route path="/">
         <Route index element={<UnfilterableProgram />} />
+	<Route path="/index.html" element={<UnfilterableProgram />} />
       </Route>
       <Route path="*" element={<NotFound />} />
     </Routes>


### PR DESCRIPTION
This is a minor edit to add routes for index.html.  The fact that index.html returned an (internal, not HTTP) error message about not finding index.html disturbed one of our developers.