### PR TITLE
Tag links

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ The main place customisations go is the `src/config.json` file. Settings current
 - `EXPAND.EXPAND_ALL_LABEL`: Label text for Expand All button.
 - `EXPAND.COLLAPSE_ALL_LABEL`: Label for Collapse All button.
 - `ITEM_DESCRIPTION.PURIFY_OPTIONS`: Pass additional options to DOMPurify when processing item descriptions.  For the available options, see [the DOMPurify documentation](https://github.com/cure53/DOMPurify#can-i-configure-dompurify).  Format options as JSON, *e.g.*, `{"FORBID_ATTR": ["style"]}`.
-- `LINKS.MEETING`: Text to display on meeting links.
-- `LINKS.RECORDING`: Text to display on recording links.
+- `LINKS`: An array of link types expected in the program data.  Individual entries should take the form `{"NAME": "signup", "TEXT": "Click to sign up", "TAG": ""}`.  `NAME` should be the name of the link as it appears in the links object in the program data.  `TEXT` is the text that should appear on this link in ConClár.  `TAG` is an optional tag to add to every program item which includes a matching link.  If using prefixed tags, include the prefix, *e.g.*, `"type:Workshop"`.
 - `LOCAL_TIME.CHECKBOX_LABEL`: Label for the "Show Local Time" checkbox.
 - `LOCAL_TIME.NOTICE`: Label for notie telling users how local time displayed.
 - `LOCAL_TIME.PREV_DAY`: Label appended to local time if local time is before start of advertised day.

--- a/src/App.css
+++ b/src/App.css
@@ -424,16 +424,25 @@ input.switch:checked ~ label:after {
   float: right;
 }
 
-.item-permalink a {
+.item-permalink a,
+.item-links a {
   transition: color 0.4s;
   color: var(--permalink-icon-fg);
 }
-.item-permalink a:visited {
+.item-permalink a:visited,
+.item-links a:visited {
   color: var(--permalink-icon-fg);
 }
-.item-permalink a:hover {
+.item-permalink a:hover,
+.item-links a:hover {
   color: var(--permalink-icon-hover-fg);
 }
+
+/* fix link spacing */
+
+ .item-links {
+   margin-top: 0.3rem;
+ }
 
 .item-people {
   margin: 0.5rem 0;

--- a/src/ProgramData.js
+++ b/src/ProgramData.js
@@ -98,6 +98,18 @@ export class ProgramData {
     return program;
   }
 
+  static tagLinks(program) {
+    const linksToTag = configData.LINKS.filter(link => link.TAG.length > 0);
+    //TAG should include an appropriate prefix if using them.
+    for (let linkToTag of linksToTag) {
+      for (let item of program) {
+	if (item.hasOwnProperty("links") && item.links.hasOwnProperty(linkToTag.NAME))
+          item.tags.push(linkToTag.TAG);
+      }
+    }
+    return program;
+  }
+
   // Extract tags from program.
   static processTags(program) {
     //Pre-parse grenadine Format as konopas Type.
@@ -154,7 +166,10 @@ export class ProgramData {
   // Process data from program and people.
   static processData(progData, pplData) {
     let program = this.processProgramData(progData);
-    if (configData.TAGS.FORMAT_AS_TAG) program = this.reformatAsTag(program);
+    if (configData.TAGS.FORMAT_AS_TAG)
+      program = this.reformatAsTag(program);
+    if (configData.LINKS && configData.LINKS.filter(link => link.TAG.length > 0).length > 0)
+      program = this.tagLinks(program);
     const people = this.processPeopleData(pplData);
     this.addProgramParticipantDetails(program, people);
     const locations = this.processLocations(program);

--- a/src/components/ItemLink.js
+++ b/src/components/ItemLink.js
@@ -1,0 +1,8 @@
+
+const ItemLink = ({ name, link, text }) => {
+  return <div className={name}>
+    <a href={link}>{text}</a>
+  </div>;
+};
+
+export default ItemLink;

--- a/src/components/ProgramItem.js
+++ b/src/components/ProgramItem.js
@@ -79,30 +79,18 @@ const ProgramItem = ({ item, forceExpanded }) => {
     item.desc,
     configData.ITEM_DESCRIPTION.PURIFY_OPTIONS
   );
-  const signupLink =
-    item.links && item.links.signup && item.links.signup.length ? (
-      <div className="item-links-signup">
-        <a href={item.links.signup}>{configData.LINKS.SIGNUP}</a>
+
+  const links = (configData.LINKS).map((link) => (
+    item.links && item.links[link.NAME] && item.links[link.NAME].length ? (
+      <div className="item-links-{link.NAME]}">
+        <a href={item.links[link.NAME]}>{link.TEXT}</a>
       </div>
     ) : (
       ""
-    );
-  const meetingLink =
-    item.links && item.links.meeting && item.links.meeting.length ? (
-      <div className="item-links-meeting">
-        <a href={item.links.meeting}>{configData.LINKS.MEETING}</a>
-      </div>
-    ) : (
-      ""
-    );
-  const recordingLink =
-    item.links && item.links.recording && item.links.recording.length ? (
-      <div className="item-links-recording">
-        <a href={item.links.recording}>{configData.LINKS.RECORDING}</a>
-      </div>
-    ) : (
-      ""
-    );
+    )
+  )
+  );
+
   const duration =
     configData.DURATION.SHOW_DURATION && item.mins ? (
       <div className="item-duration">
@@ -167,9 +155,7 @@ const ProgramItem = ({ item, forceExpanded }) => {
               dangerouslySetInnerHTML={{ __html: safeDesc }}
             />
             <div className="item-links">
-              {signupLink}
-              {meetingLink}
-              {recordingLink}
+              {links}
             </div>
           </div>
         </animated.div>

--- a/src/components/ProgramItem.js
+++ b/src/components/ProgramItem.js
@@ -5,6 +5,7 @@ import useMeasure from "react-use-measure";
 import { useSpring, animated } from "react-spring";
 import { IoChevronDownCircle } from "react-icons/io5";
 import { HiLink } from "react-icons/hi";
+import ItemLink from "./ItemLink";
 import Location from "./Location";
 import Tag from "./Tag";
 import Participant from "./Participant";
@@ -80,16 +81,21 @@ const ProgramItem = ({ item, forceExpanded }) => {
     configData.ITEM_DESCRIPTION.PURIFY_OPTIONS
   );
 
-  const links = (configData.LINKS).map((link) => (
-    item.links && item.links[link.NAME] && item.links[link.NAME].length ? (
-      <div className="item-links-{link.NAME]}">
-        <a href={item.links[link.NAME]}>{link.TEXT}</a>
-      </div>
-    ) : (
-      ""
-    )
-  )
-  );
+  const links = [];
+  if (configData.LINKS) {
+    configData.LINKS.forEach((link) => {
+      if (item.links && item.links[link.NAME] && item.links[link.NAME].length) {
+	links.push(
+          <ItemLink
+            key={link.NAME} 
+            name={"item-links-" + link.NAME}
+            link={item.links[link.NAME]}
+            text={link.TEXT}
+          />
+	);
+      }
+    });
+  };
 
   const duration =
     configData.DURATION.SHOW_DURATION && item.mins ? (

--- a/src/config.json
+++ b/src/config.json
@@ -36,11 +36,20 @@
   "ITEM_DESCRIPTION": {
     "PURIFY_OPTIONS": {}
   },
-  "LINKS": {
-    "SIGNUP": "Click to sign up",
-    "MEETING": "Click to view stream",
-    "RECORDING": "Click to view recording"
-  },
+  "LINKS": [
+    {"NAME": "signup",
+     "TEXT": "Click to sign up",
+     "TAG": ""
+    },
+    {"NAME": "meeting",
+     "TEXT": "Click to view stream",
+     "TAG": ""
+    },
+    {"NAME": "recording",
+     "TEXT": "Click to view recording",
+     "TAG": "Recording available"
+    }
+  ],
   "LOCAL_TIME": {
     "CHECKBOX_LABEL": "Show local time",
     "NOTICE": "Local time shown in italics.",

--- a/src/config.json
+++ b/src/config.json
@@ -43,11 +43,11 @@
     },
     {"NAME": "meeting",
      "TEXT": "Click to view stream",
-     "TAG": ""
+     "TAG": "type:Streaming"
     },
     {"NAME": "recording",
      "TEXT": "Click to view recording",
-     "TAG": "Recording available"
+     "TAG": ""
     }
   ],
   "LOCAL_TIME": {


### PR DESCRIPTION
This PR does two things: parametrizes item link handling as discussed in issue #70, and allows automated tagging of items based on their links.  I had implemented the latter in a hard-coded way in my virtcon branch (which is for the gated version of the schedule where we had signups, meeting, and now recording links), so this code is a bit cleaner.  Sorry the merge isn't magic; that's probably because I restructured the LINKS config section.

Note that one free bit of functionality is that link types can easily be removed from the schedule by leaving them out of the config (rather than manually editing or otherwise changing the source data).