### PR TITLE
Use Temporal API for more robust date handling.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "conclar",
       "version": "0.1.0",
       "dependencies": {
+        "@js-temporal/polyfill": "^0.4.0",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
@@ -2395,6 +2396,18 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.4.0.tgz",
+      "integrity": "sha512-j6DwrVV5e2fj3pdXXx6e4ol9/VWg+hX54xOUJjNx+PekzWdjkVzBLpttPNczFcY1W0SFv2ovxrsz/OB4SzIALA==",
+      "dependencies": {
+        "jsbi": "^4.1.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7095,9 +7108,9 @@
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "funding": [
         {
           "type": "individual",
@@ -9134,6 +9147,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbi": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.2.0.tgz",
+      "integrity": "sha512-JzhwPkH7Ra8O1b5uHmWxl6N8ZumqGvMXgpKcsq0/iWlnB+KkzbekCIcLl3hu3sFGTLNXAuXIqY4STtE0ZfT1zA=="
+    },
     "node_modules/jsdom": {
       "version": "16.7.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
@@ -10447,9 +10465,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/mkdirp": {
       "version": "0.5.5",
@@ -10531,9 +10549,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
-      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -17648,6 +17666,15 @@
         "chalk": "^4.0.0"
       }
     },
+    "@js-temporal/polyfill": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.4.0.tgz",
+      "integrity": "sha512-j6DwrVV5e2fj3pdXXx6e4ol9/VWg+hX54xOUJjNx+PekzWdjkVzBLpttPNczFcY1W0SFv2ovxrsz/OB4SzIALA==",
+      "requires": {
+        "jsbi": "^4.1.0",
+        "tslib": "^2.3.1"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -21154,9 +21181,9 @@
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw=="
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "6.5.0",
@@ -22609,6 +22636,11 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbi": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.2.0.tgz",
+      "integrity": "sha512-JzhwPkH7Ra8O1b5uHmWxl6N8ZumqGvMXgpKcsq0/iWlnB+KkzbekCIcLl3hu3sFGTLNXAuXIqY4STtE0ZfT1zA=="
+    },
     "jsdom": {
       "version": "16.7.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
@@ -23487,9 +23519,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mkdirp": {
       "version": "0.5.5",
@@ -23553,9 +23585,9 @@
       }
     },
     "node-forge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
-      "integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@js-temporal/polyfill": "^0.4.0",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",

--- a/src/components/Day.js
+++ b/src/components/Day.js
@@ -1,33 +1,34 @@
 import PropTypes from "prop-types";
 import TimeSlot from "./TimeSlot";
 import { LocalTime } from "../utils/LocalTime";
+//import { IoSyncCircleOutline } from "react-icons/io5";
 
 const Day = ({ date, items, forceExpanded }) => {
   const day = LocalTime.formatDateForLocaleAsUTC(date);
   const rows = [];
   let itemRows = [];
-  let curTime = null;
+  let curDateAndTime = null;
   items.forEach((item) => {
-    if (item.time !== curTime) {
+    if (curDateAndTime === null || !item.dateAndTime.equals(curDateAndTime)) {
       if (itemRows.length > 0) {
         rows.push(
           <TimeSlot
-            key={curTime}
-            time={curTime}
+            key={curDateAndTime.toString()}
+            dateAndTime={curDateAndTime}
             items={itemRows}
             forceExpanded={forceExpanded}
           />
         );
         itemRows = [];
       }
-      curTime = item.time;
+      curDateAndTime = item.dateAndTime;
     }
     itemRows.push(item);
   });
   rows.push(
     <TimeSlot
-      key={curTime}
-      time={curTime}
+      key={curDateAndTime.toString()}
+      time={curDateAndTime}
       items={itemRows}
       forceExpanded={forceExpanded}
     />

--- a/src/components/TimeSlot.js
+++ b/src/components/TimeSlot.js
@@ -3,20 +3,20 @@ import { useStoreState } from "easy-peasy";
 import ProgramItem from "./ProgramItem";
 import { LocalTime } from "../utils/LocalTime";
 
-const TimeSlot = ({ time, items, forceExpanded }) => {
+const TimeSlot = ({ dateAndTime, items, forceExpanded }) => {
   const showLocalTime = useStoreState((state) => state.showLocalTime);
   const show12HourTime = useStoreState((state) => state.show12HourTime);
   const offset = useStoreState((state) => state.offset);
-  if (!time) return "";
+  if (!dateAndTime) return "";
   const conTime = (
     <div className="time-convention">
-      {LocalTime.formatTimeInConventionTimeZone(time, show12HourTime)}
+      {LocalTime.formatTimeInConventionTimeZone(dateAndTime, show12HourTime)}
     </div>
   );
   const localTime =
     offset !== null && offset !== 0 && showLocalTime ? (
       <div className="time-local">
-        {LocalTime.formatTimeInLocalTimeZone(time, offset, show12HourTime)}
+        {LocalTime.formatTimeInLocalTimeZone(dateAndTime, offset, show12HourTime)}
       </div>
     ) : (
       ""
@@ -29,7 +29,7 @@ const TimeSlot = ({ time, items, forceExpanded }) => {
   });
 
   return (
-    <div id={time} className="timeslot">
+    <div id={dateAndTime.toString()} className="timeslot">
       <div className="timeslot-time">
         {conTime}
         {localTime}
@@ -44,7 +44,6 @@ TimeSlot.defaultProps = {
 };
 
 TimeSlot.propTypes = {
-  time: PropTypes.string,
   items: PropTypes.array,
   forceExpanded: PropTypes.bool,
 };


### PR DESCRIPTION
This change uses the Temporal API, which is a proposed new date handling extension for JavaScript. As browsers don't yet support it, it has been added via the `@js-temporal/polyfill` library.

During processing, each program item has a `dateAndTime` field populated with is a `Temporal.zonedDateTime` field in the convention timezone. When displaying the output, can use the `withTimeZone` method to convert to the browser timezone, which cuts down the complexity of the code considerably.

It also converts the local and convention zonedDateTime values to PlainDate values. Comparing these lets us check if the item is on the previous or next day, and add a label accordingly.

I haven't looked at the code that checks if convention is currently ongoing, but I think this could also be considerably simplified.