### PR TITLE
Changed tags to use 'hasOwnProperty' as IN was misbehaving.

### DIFF
--- a/src/ProgramData.js
+++ b/src/ProgramData.js
@@ -136,7 +136,7 @@ export class ProgramData {
     }
 
     // For each tag prefix we want to separate, add a property.
-    if ("SEPARATE" in configData.TAGS) {
+    if (configData.TAGS.hasOwnProperty("SEPARATE")) {
       for (const tag of configData.TAGS.SEPARATE) {
         tags[tag.PREFIX] = [];
       }


### PR DESCRIPTION
Tags were not getting separated for Reclamation. ProgramData.js was not seeing the `SEPARATE` property of TAGS in config.

Changed from using `in` to `hasOwnProperty` for checking presence of property, and seems to have resolved issue, but not sure why `in` stopped working when it had previously.

Also some minor indentation and formatting changes.