### PR TITLE
Allow tags to be specified as strings or objects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,13 @@ The main place customisations go is the `src/config.json` file. Settings current
 - `LOCATIONS.SEARCHABLE`: Whether the location list can be searched by typing. (Searching can be inconvenient on touch screens.)
 - `TAGS.PLACEHOLDER`: The placeholder when selecting tags (unless separated).
 - `TAGS.SEARCHABLE`: Whether the tag list can be searched by typing (unless separated).
-- `TAGS.SEPARATE`: An array of tag prefixes to separate into individual drop-downs. Tags should be specified as follows: `{ "PREFIX": "type", "PLACEHOLDER": "Select type" }`.
+- `TAGS.HIDE`: If true, hide the tags drop-down. Tags still displayed on items.
+- `TAGS.SEPARATE`: An array of tag prefixes to separate into individual drop-downs, and if drop-down is searchable or hidden. Tags should be specified as follows: `{ "PREFIX": "type", "PLACEHOLDER": "Select type", "SEARCHABLE": true|false, "HIDE": true|false }`.
 - `TAGS.FORMAT_AS_TAG`: If set to true, turns Grenadine item format into a KonOpas-style "type" tag.
 - `TAGS.DAY_TAG.GENERATE`: If set to true, will generate tags for each day of the convention.
 - `TAGS.DAY_TAG.PLACEHOLDER`: The placeholder for the "day" tags drop down.
 - `TAGS.DAY_TAG.SEARCHABLE`: Whether day tag list can be searched by typing.
+- `TAGS.DAY_TAG.HIDE`: If true, hide day tags drop-down. Day tags still shown on items if GENERATE true.
 - `PERMALINK.SHOW_PERMALINK`: If true, display a "permalink" icon when each program item is expanded.
 - `PERMALINK.PERMALINK_TITLE`: "Title" text displayed when mouse is hovered over permalink icon.
 - `EXPAND.EXPAND_ALL_LABEL`: Label text for Expand All button.

--- a/docs/conclar_file_specs.md
+++ b/docs/conclar_file_specs.md
@@ -59,7 +59,10 @@ var program = [
 	{
 		"id": "112eeabc-ef56-4197-9191-ce2aa3aea38e",
 		"title": "A Really Cool Item Title",
-		"tags": [ "Some track", "Another track" ],
+		"tags": [
+			{ "value": "tag01", "label": "Some track" },
+			{ "value": "tag02", "label": "Another track" }
+		],
 		"datetime": "2013-12-24T14:30:00+00:00",
 		"mins": "90",
 		"loc": [ "Some Room", "Some Area" ],
@@ -73,7 +76,13 @@ var program = [
 	{
 		"id": "29f103c8-d492-49c6-a971-6a4a69fe49ff",
 		"title": "An Interview with the Knight of Honour",
-		"tags": [ "Track: Art", "Division: Program", "Tag: GoH", "Tag: Another tag" ],
+		"tags": [
+			{ "value": "tag01" },
+			{ "value": "tag03", "category": "Track", "label": "Art" },
+			{ "value": "tag04", "category": "Division", "label": "Program" },
+			{ "value": "tag05", "category": "Tag", "label": "GoH" },
+			{ "value": "tag06", "category": "Tag", "label": "Another tag" }
+		],
 		"date": "2013-12-25T23:30:00+00:00",
 		"mins": "45",
 		"loc": [ "Another Room", "Some Area" ],
@@ -92,10 +101,14 @@ var program = [
 ]
 ```
 
+Note: the "old" and "new" style files are not mutually exclusive, and it is possible to mix elements of both. However, if compatibility with KonOpas is required, old style should be used.
+
 * `var program =` and the trailing semicolon are completely optional. They were needed by KonOpas, but ConClár ignores everything outside square brackets. `program` must be the first array in the file if multiple entries in file (discouraged).
 * `id` is a unique id to a programme item. This id is referred to by the `prog` field in the `people` array. There is no particular format it has to follow as long as each entry is unique.
 * `title` is the title of the programme item.
-* `tags` may include any number of programme tracks or other classifying indicators in this array. These different tags can have prefixes (such as "Track:" or "Division:" to split out the type of tag.
+* `tags` may include any number of programme tracks or other classifying indicators in this array.
+  * May be a single string. String tags can have optional prefixes (such as "Track:" or "Division:") to split out the category of tag.
+	* Alternatively, may be an object in the form `{ "value": "tag ID", "category": "tag category", "label": "label to display" }`. `category` is optional. If using this form, the cagegory and label need only be specified once, and subsequent references to the tag need only specify the `value`.
 * `format` optional field used by Grenadine. Treated as a `tag` if present.
 * `date` is the date of when the item will happen.
 * `time` is the time of when the programme item will start. It assumes that the timezone of the item is the same as the server.

--- a/src/ProgramData.js
+++ b/src/ProgramData.js
@@ -12,7 +12,8 @@ import { LocalTime } from "./utils/LocalTime";
  */
 
 export class ProgramData {
-  static regex = /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(\.\d{3})?(Z)?([+-]\d{2}:\d{2})?/;
+  static regex =
+    /(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(\.\d{3})?(Z)?([+-]\d{2}:\d{2})?/;
 
   /**
    * Process a program item and return the date and time as a ZonedDateTime.
@@ -205,19 +206,62 @@ export class ProgramData {
   static processTags(program) {
     //Pre-parse grenadine Format as konopas Type.
 
-    // Tags is an object with a property for each tag type. Default to one property for general tags.
-    const tags = { tags: [] };
+    // Tags is an object with a property for each tag type. Default to a property for general tags, and one for an index of all tags.
+    const tags = { tags: [], all: {} };
 
-    // Subfunction to push tag to tag list.
-    function addTag(tagList, value, label) {
+    /**
+     * Subfunction to push tag to tag list.
+     * @param {array} tagList The tag array to add tag to if not already present.
+     * @param {object} tag The tag object to add.
+     * @returns {object} The tag object added.
+     */
+    function addTag(tagList, tag) {
       // If item doesn't exist in tags array, add it.
       if (
         !tagList.find((entry) => {
-          return value === entry.value;
+          return tag.value === entry.value;
         })
       ) {
-        tagList.push({ value: value, label: label });
+        tagList.push(tag);
       }
+      return tag;
+    }
+
+    /**
+     * Takes a tag string and decodes into a tag object. Adds to tags.all array.
+     * @param {*} tag
+     * @returns
+     */
+    function decodeTag(tag) {
+      const hasProps = tag.hasOwnProperty("value");
+      const value = hasProps ? tag.value : tag;
+      const newTag = tags.all.hasOwnProperty(value)
+        ? tags.all[value]
+        : { value: value };
+      // If tag has properties, apply label and category to stored tag if present.
+      if (hasProps) {
+        if (tag.hasOwnProperty("label")) newTag.label = tag.label;
+        if (tag.hasOwnProperty("category")) newTag.category = tag.category;
+        tags.all[value] = newTag;
+        return newTag;
+      }
+      // If we get here, it's an old style tag.
+      const matches = tag.match(/^(.+):(.+)/);
+      if (matches && matches.length === 3) {
+        const prefix = matches[1];
+        const label = matches[2];
+        // Tag has a prefix. Check if it's one we're interested in.
+        if (prefix in tags) {
+          newTag.category = prefix;
+          newTag.label = Format.formatTag(label);
+        } else {
+          newTag.label = tag;
+        }
+      } else {
+        newTag.label = tag;
+      }
+      tags.all[value] = newTag;
+      return newTag;
     }
 
     // For each tag prefix we want to separate, add a property.
@@ -229,27 +273,31 @@ export class ProgramData {
     for (const item of program) {
       // Check item has at least one tag.
       if (item.tags && Array.isArray(item.tags) && item.tags.length) {
-        for (const tag of item.tags) {
-          const matches = tag.match(/^(.+):(.+)/);
-          if (matches && matches.length === 3) {
-            const prefix = matches[1];
-            const label = matches[2];
-            // Tag has a prefix. Check if it's one we're interested in.
-            if (prefix in tags) {
-              addTag(tags[prefix], tag, label);
-            } else {
-              addTag(tags.tags, tag, Format.formatTag(tag));
-            }
-          } else {
-            // Tag does not have a prefix, so add to default tags list.
-            addTag(tags.tags, tag, tag);
-          }
-        }
+        item.tags.forEach((tag, index) => {
+          item.tags[index] = decodeTag(tag);
+        });
       }
     }
+    // Now we've got tags in tags.all array, split them into categories.
+    for (const value in tags.all) {
+      const tag = tags.all[value];
+      if (tag.hasOwnProperty("category")) {
+        // If category has own drop-down, add to that drop-down.
+        if (tags.hasOwnProperty(tag.category)) {
+          tags[tag.category].push(tag);
+        } else {
+          tags.tags.push(tag);
+        }
+      } else {
+        // Otherwise add to generic tags.
+        tags.tags.push(tag);
+      }
+    }
+
     // Now sort each set of tags.
-    for (let tagList in tags) {
-      tags[tagList].sort((a, b) => a.label.localeCompare(b.label));
+    for (const tagList in tags) {
+      if (Array.isArray(tags[tagList]))
+        tags[tagList].sort((a, b) => a.label.localeCompare(b.label));
     }
 
     // If generating day tags, loop through days and add a tag for day in convention timezone.
@@ -257,10 +305,22 @@ export class ProgramData {
       tags.days = [];
       for (const item of program) {
         // Get the day of the program item.
-        const dayLabel = LocalTime.formatDayNameInConventionTimeZone(item.dateAndTime);
-        const dayValue = LocalTime.formatISODateInConventionTimeZone(item.dateAndTime);
-        item.tags.push(dayValue);
-        addTag(tags.days, dayValue, dayLabel);
+        const dayValue = LocalTime.formatISODateInConventionTimeZone(
+          item.dateAndTime
+        );
+        const dayTag = tags.days.includes(dayValue)
+          ? tags.days[dayValue]
+          : addTag(tags.days, {
+              value: dayValue,
+              label: LocalTime.formatDayNameInConventionTimeZone(
+                item.dateAndTime
+              ),
+              category: "days",
+            });
+        if (!tags.all.hasOwnProperty(dayValue)) {
+          tags.all[dayValue] = dayTag;
+        }
+        item.tags.push(dayTag);
       }
       // Sort days by value.
       tags.days.sort((a, b) => a.value.localeCompare(b.value));
@@ -278,7 +338,6 @@ export class ProgramData {
    * @returns {object}
    */
   static processData(progData, pplData) {
-    console.log(progData);
     let program = this.processProgramData(progData);
     if (configData.TAGS.FORMAT_AS_TAG) program = this.reformatAsTag(program);
     if (
@@ -307,14 +366,14 @@ export class ProgramData {
    * @returns {object}
    */
   static async fetchUrl(url) {
-      const res = await fetch(url, configData.FETCH_OPTIONS);
-      const data = await res.text();
-      return JsonParse.extractJson(data);
+    const res = await fetch(url, configData.FETCH_OPTIONS);
+    const data = await res.text();
+    return JsonParse.extractJson(data);
   }
 
   /**
    * Work out whether to read one or two files, and read the data.
-   * 
+   *
    * @returns {array}
    */
   static async fetchData() {

--- a/src/components/FilterableProgram.js
+++ b/src/components/FilterableProgram.js
@@ -27,6 +27,11 @@ const FilterableProgram = () => {
   const total = filtered.length;
   const totalMessage = `Listing ${total} items`;
 
+  /**
+   * Apply filters to the program array.
+   * @param {array} program Array of program items.
+   * @returns {array} The filtered array.
+   */
   function applyFilters(program) {
     const term = search.trim().toLowerCase();
 
@@ -67,7 +72,7 @@ const FilterableProgram = () => {
         filtered = filtered.filter((item) => {
           for (const tag of item.tags) {
             for (const selected of selTags[tagType]) {
-              if (selected.value === tag) return true;
+              if (selected.value === tag.value) return true;
             }
           }
           return false;
@@ -80,6 +85,11 @@ const FilterableProgram = () => {
     return filtered;
   }
 
+  /**
+   * Get the tag information for the tag category.
+   * @param {string} tag The tag category.
+   * @returns {object} The tag config information.
+   */
   function findTagData(tag) {
     // Check for day tag.
     if (tag === 'days' && configData.TAGS.DAY_TAG.GENERATE)
@@ -95,8 +105,8 @@ const FilterableProgram = () => {
   const tagFilters = [];
   for (const tag in tags) {
     const tagData = findTagData(tag);
-    // Only add drop-down if tag type actually contains elements.
-    if (tags[tag].length) {
+    // Only add drop-down if tag type actually contains elements, and isn't marked hidden in config.
+    if (tags[tag].length && !tagData.HIDE) {
       tagFilters.push(
         <div key={tag} className={"filter-tags filter-tags-" + tag}>
           <ReactSelect

--- a/src/components/ProgramItem.js
+++ b/src/components/ProgramItem.js
@@ -62,8 +62,8 @@ const ProgramItem = ({ item, forceExpanded }) => {
     );
 
   const tags = [];
-  for (let tag of item.tags) {
-    tags.push(<Tag key={tag} tag={tag} />);
+  for (const tag of item.tags) {
+    tags.push(<Tag key={tag.value} tag={tag.label} />);
   }
 
   const people = [];

--- a/src/config.json
+++ b/src/config.json
@@ -32,15 +32,17 @@
   "TAGS": {
     "PLACEHOLDER": "Select tags",
     "SEARCHABLE": false,
+    "HIDE": false,
     "SEPARATE": [
-      { "PREFIX": "type", "PLACEHOLDER": "Select type", "SEARCHABLE": true },
-      { "PREFIX": "test", "PLACEHOLDER": "Select test", "SEARCHABLE": true }
+      { "PREFIX": "type", "PLACEHOLDER": "Select type", "SEARCHABLE": true, "HIDE": false },
+      { "PREFIX": "test", "PLACEHOLDER": "Select test", "SEARCHABLE": true, "HIDE": false }
     ],
     "FORMAT_AS_TAG": false,
     "DAY_TAG": {
       "GENERATE": true,
       "PLACEHOLDER": "Select days",
-      "SEARCHABLE": true
+      "SEARCHABLE": true,
+      "HIDE": false
     }
   },
   "PERMALINK": {

--- a/src/utils/Format.js
+++ b/src/utils/Format.js
@@ -1,5 +1,9 @@
 export class Format {
-  // If tag contains a ":", capitalise the part before the colon, and add a space after the colon.
+  /**
+   * If tag contains a ":", capitalise the part before the colon, and add a space after the colon.
+   * @param {string} raw
+   * @returns string
+   */
   static formatTag(raw) {
     let matches = raw.match(/^(.+):(.+)$/);
     if (matches && matches.length >= 3)


### PR DESCRIPTION
Now allows tags in program file to be specified as objects instead of strings.
If string tags are used, they will be parsed into objects internally.
If objects used, should follow the format: `{ "value": "tag ID", "category": "tag category", "label": "label to display" }`

Also adds HIDE property to TAG in config, to allow a tag category to not have a drop-down, though the tags still appear on program items.