### PR TITLE
Require http/https on participant links.

### DIFF
--- a/src/components/PersonLinks.js
+++ b/src/components/PersonLinks.js
@@ -12,7 +12,7 @@ import {
 
 
 const PersonLinks = ({ person }) => {
-  const regex = /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=.]+$/;
+  const regex = /^(?:http(s)?:\/\/)[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=.]+$/;
   /**
    * Take a link type and return an appropriate Icon.
    * @param {string} type 


### PR DESCRIPTION
Fix an issue that links without protocol were interpreted as local links. Fix is to not display links unless protocol included.