### PR TITLE
Add components for tag drop-downs and make tag processing generic.

### DIFF
--- a/src/ProgramData.js
+++ b/src/ProgramData.js
@@ -198,12 +198,13 @@ export class ProgramData {
   }
 
   /**
-   * Extract tags from program.
+   * Extract tags from program or participants.
    *
-   * @param {array} program
+   * @param {array} taggedItems The program or participant data to extract tags from.
+   * @param {object} tagConfig The config section to use.
    * @returns {array}
    */
-  static processTags(program) {
+  static processTags(taggedItems, tagConfig) {
     //Pre-parse grenadine Format as konopas Type.
 
     // Tags is an object with a property for each tag type. Default to a property for general tags, and one for an index of all tags.
@@ -265,12 +266,12 @@ export class ProgramData {
     }
 
     // For each tag prefix we want to separate, add a property.
-    if (configData.TAGS.hasOwnProperty("SEPARATE")) {
-      for (const tag of configData.TAGS.SEPARATE) {
+    if (tagConfig.hasOwnProperty("SEPARATE")) {
+      for (const tag of tagConfig.SEPARATE) {
         tags[tag.PREFIX] = [];
       }
     }
-    for (const item of program) {
+    for (const item of taggedItems) {
       // Check item has at least one tag.
       if (item.tags && Array.isArray(item.tags) && item.tags.length) {
         item.tags.forEach((tag, index) => {
@@ -301,10 +302,10 @@ export class ProgramData {
     }
 
     // If generating day tags, loop through days and add a tag for day in convention timezone.
-    if (configData.TAGS.DAY_TAG.GENERATE) {
+    if (tagConfig.hasOwnProperty("DAY_TAG") && tagConfig.DAY_TAG.GENERATE) {
       tags.days = [];
-      for (const item of program) {
-        // Get the day of the program item.
+      for (const item of taggedItems) {
+        // Get the day of the program (this shouldn't apply for participants) item.
         const dayValue = LocalTime.formatISODateInConventionTimeZone(
           item.dateAndTime
         );
@@ -348,7 +349,7 @@ export class ProgramData {
     const people = this.processPeopleData(pplData);
     this.addProgramParticipantDetails(program, people);
     const locations = this.processLocations(program);
-    const tags = this.processTags(program);
+    const tags = this.processTags(program, configData.TAGS);
     LocalTime.checkTimezonesDiffer(program);
 
     return {

--- a/src/components/FilterableProgram.js
+++ b/src/components/FilterableProgram.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import ReactSelect from "react-select";
 import { useStoreState, useStoreActions } from "easy-peasy";
+import TagSelectors from "./TagSelectors";
 import ProgramList from "./ProgramList";
 import ShowPastItems from "./ShowPastItems";
 import configData from "../config.json";
@@ -22,7 +23,7 @@ const FilterableProgram = () => {
   const [search, setSearch] = useState("");
   const [selLoc, setSelLoc] = useState([]);
   const [selTags, setSelTags] = useState({});
-
+  
   const filtered = applyFilters(program);
   const total = filtered.length;
   const totalMessage = `Listing ${total} items`;
@@ -85,46 +86,9 @@ const FilterableProgram = () => {
     return filtered;
   }
 
-  /**
-   * Get the tag information for the tag category.
-   * @param {string} tag The tag category.
-   * @returns {object} The tag config information.
-   */
-  function findTagData(tag) {
-    // Check for day tag.
-    if (tag === 'days' && configData.TAGS.DAY_TAG.GENERATE)
-      return configData.TAGS.DAY_TAG;
-    const tagData = configData.TAGS.SEPARATE.find((item) => item.PREFIX === tag );
-    if (tagData !== undefined)
-      return tagData;
-    // Tag not found in config, so return default.
-    return configData.TAGS;
-  }
 
   // TODO: Probably should move the tags filter to its own component.
-  const tagFilters = [];
-  for (const tag in tags) {
-    const tagData = findTagData(tag);
-    // Only add drop-down if tag type actually contains elements, and isn't marked hidden in config.
-    if (tags[tag].length && !tagData.HIDE) {
-      tagFilters.push(
-        <div key={tag} className={"filter-tags filter-tags-" + tag}>
-          <ReactSelect
-            placeholder={tagData.PLACEHOLDER}
-            options={tags[tag]}
-            isMulti
-            isSearchable={tagData.SEARCHABLE}
-            value={selTags[tag]}
-            onChange={(value) => {
-              let selections = { ...selTags };
-              selections[tag] = value;
-              setSelTags(selections);
-            }}
-          />
-        </div>
-      );
-    }
-  }
+
 
   return (
     <div>
@@ -140,7 +104,12 @@ const FilterableProgram = () => {
               onChange={(value) => setSelLoc(value)}
             />
           </div>
-          {tagFilters}
+          <TagSelectors
+            tags={tags}
+            selTags={selTags}
+            setSelTags={setSelTags}
+            tagConfig={configData.TAGS}
+          />
           <div className="filter-search">
             <input
               type="text"

--- a/src/components/TagSelect.js
+++ b/src/components/TagSelect.js
@@ -1,0 +1,20 @@
+import ReactSelect from "react-select";
+
+const TagSelect = ({ options, tag, selTags, setSelTags, tagData }) => {
+  return (
+    <ReactSelect
+      placeholder={tagData.PLACEHOLDER}
+      options={options}
+      isMulti
+      isSearchable={tagData.SEARCHABLE}
+      value={selTags[tag]}
+      onChange={(value) => {
+        let selections = { ...selTags };
+        selections[tag] = value;
+        setSelTags(selections);
+      }}
+    />
+  );
+};
+
+export default TagSelect;

--- a/src/components/TagSelectors.js
+++ b/src/components/TagSelectors.js
@@ -1,0 +1,42 @@
+import TagSelect from "./TagSelect";
+
+const TagSelectors = ({ tags, selTags, setSelTags, tagConfig }) => {
+  /**
+   * Get the tag information for the tag category.
+   * @param {string} tag The tag category.
+   * @returns {object} The tag config information.
+   */
+  function findTagData(tag) {
+    // Check for day tag.
+    if (tag === "days" && tagConfig.DAY_TAG.GENERATE)
+      return tagConfig.DAY_TAG;
+    const tagData = tagConfig.SEPARATE.find(
+      (item) => item.PREFIX === tag
+    );
+    if (tagData !== undefined) return tagData;
+    // Tag not found in config, so return default.
+    return tagConfig;
+  }
+
+  const tagFilters = [];
+  for (const tag in tags) {
+    const tagData = findTagData(tag);
+    // Only add drop-down if tag type actually contains elements, and isn't marked hidden in config.
+    if (tags[tag].length && !tagData.HIDE) {
+      tagFilters.push(
+        <div key={tag} className={"filter-tags filter-tags-" + tag}>
+          <TagSelect
+            options={tags[tag]}
+            tag={tag}
+            selTags={selTags}
+            setSelTags={setSelTags}
+            tagData={tagData}
+          />
+        </div>
+      );
+    }
+  }
+  return <>{tagFilters}</>;
+};
+
+export default TagSelectors;


### PR DESCRIPTION
- Move tag selection components off FilterableProgram component into TagSelectors, which contains TagSelect components that can be reused on participants.
- Alter ProcessTags function to not refer explicitly to program tags, so it can be reused for participant tags.

This change is to prepare for a future change to add participant tags.