### PR TITLE
Add tags to people page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ The main place customisations go is the `src/config.json` file. Settings current
 - `PEOPLE.TAGS.SEARCHABLE`: Whether the tag list can be searched by typing (unless separated).
 - `PEOPLE.TAGS.HIDE`: If true, hide the tags drop-down. Tags still displayed on items.
 - `PEOPLE.TAGS.SEPARATE`: An array of tag prefixes to separate into individual drop-downs, and if drop-down is searchable or hidden. Tags should be specified as follows: `{ "PREFIX": "type", "PLACEHOLDER": "Select type", "SEARCHABLE": true|false, "HIDE": true|false }`.
-- `PEOPLE.TAGS.FORMAT_AS_TAG`: If set to true, turns Grenadine item format into a KonOpas-style "type" tag.
 - `PEOPLE.SEARCH.SHOW_SEARCH`: Set to false to hide "people" search box.
 - `PEOPLE.SEARCH.SEARCH_LABEL`: Label for "people2 search box.
 - `PEOPLE.BIO.PURIFY_OPTIONS`: Pass additional options to DOMPurify when processing participant bios. For more details, see `ITEM_DESCRIPTION.PURIFY_OPTIONS` above.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ The main place customisations go is the `src/config.json` file. Settings current
 - `PEOPLE.THUMBNAILS.DEFAULT_IMAGE`: Set to default thumbnail for participants with no photo. Can be filename of image in public directory, or external URL. Leave blank for no default thumbnail.
 - `PEOPLE.SORT.SHOW_CHECKBOX`: Set to false to hide "Sort by full name" checkbox. Useful if your data only contains "name for publications".
 - `PEOPLE.SORT.CHECKBOX_LABEL`: Label for "Sort by full name" checkbox.
+- `PEOPLE.TAGS.PLACEHOLDER`: The placeholder when selecting person tags (unless separated).
+- `PEOPLE.TAGS.SEARCHABLE`: Whether the tag list can be searched by typing (unless separated).
+- `PEOPLE.TAGS.HIDE`: If true, hide the tags drop-down. Tags still displayed on items.
+- `PEOPLE.TAGS.SEPARATE`: An array of tag prefixes to separate into individual drop-downs, and if drop-down is searchable or hidden. Tags should be specified as follows: `{ "PREFIX": "type", "PLACEHOLDER": "Select type", "SEARCHABLE": true|false, "HIDE": true|false }`.
+- `PEOPLE.TAGS.FORMAT_AS_TAG`: If set to true, turns Grenadine item format into a KonOpas-style "type" tag.
 - `PEOPLE.SEARCH.SHOW_SEARCH`: Set to false to hide "people" search box.
 - `PEOPLE.SEARCH.SEARCH_LABEL`: Label for "people2 search box.
 - `PEOPLE.BIO.PURIFY_OPTIONS`: Pass additional options to DOMPurify when processing participant bios. For more details, see `ITEM_DESCRIPTION.PURIFY_OPTIONS` above.

--- a/docs/conclar_file_specs.md
+++ b/docs/conclar_file_specs.md
@@ -155,7 +155,7 @@ var people = [
 		"id": "2345",
 		"name": [ "Just", "Sömeguy" ],
 		"sortname": "Sömeguy Just",
-		"tags": [],
+		"tags": [ "Virtual" ],
 		"prog": [ "1234", "416", "810" ],
 		"links": {
 			"twitter": "justsomeguy9999",
@@ -185,7 +185,7 @@ var people = [
 		"id": "972cf921-4831-4b16-a189-b5f1072ab950",
 		"name": [ "Galahad", "", "Sir" ],
 		"sortname": "Sir Galahad",
-		"tags": [ "GoH" ],
+		"tags": [ {"value": "G1", "label": "GoH"} ],
 		"prog": [ "416" ],
 		"links": {
 			"img": "/images/galahad.jpg",
@@ -199,7 +199,7 @@ var people = [
 		"id": "bf871858-39d4-4eeb-9f5f-611112262a9c",
 		"name": [ "Just", "Sömeguy" ],
 		"sortname": "Sömeguy Just",
-		"tags": [],
+		"tags": [ {"value": "v1", "label": "Virtual" } ],
 		"prog": [ "1234", "416", "810" ],
 		"links": {
 			"twitter": "justsomeguy9999",
@@ -216,12 +216,12 @@ var people = [
 * `name` is the name of the person. It can be an array in the following format: [ "First", "Last", "Prefix", "Suffix" ] or as [ "Full Name" ].
     *Note: The name field a different field in program.js’s `people` and in people.js; in the former it’s ready to print whereas in the latter it’s an array [ "First", "Last", "Prefix", "Suffix" ] with fields possibly left as empty strings or left out completely.
 * `sortname` is an alternate sort for the name field.
-* `tags` is NOT CURRENTLY IMPLEMENTED for ConClár.
+* `tags` work exactly like they do for program items. Can be either old style string or new style object, and can use categories.
 * `prog` is an array of programme ids to which the person is assigned.
 * `links` is an array of items for the person.  Currently implemented links are:
     * `img` - a link which is a path to a thumbnail image of the person;
     * `photo` - a link which is a path to a thumbnail image of the person;
-    * Not yet supported, but expect to be added soon: `url`, `fb`, and `twitter`.
+    * Other links will be displayed as icons under bio. Known link types are: `twitter`, `fb`, `facebook`, `instagram`, `twitch`, `youtube`, `tiktok`, `linkedin`, and will be shown with a suitable icon. A generic link icon will be used for other link types.
 * `img_256_url` - a link which is a path to a thumbnail image of the person (used by Grenadine). Note this is in the root level of the `people` record, not under `links`.
 * `bio` is the biography of the person.
     * Note: The fields `desc` for program.js and `bio` for people.js can support HTML tags, which get sanitized for dangerous HTML, but all other fields must be plain text.

--- a/src/App.css
+++ b/src/App.css
@@ -521,6 +521,15 @@ input.switch:checked ~ label:after {
  * 5. people.
  */
 
+.people-settings {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  padding-inline-start: 0;
+  margin: 0.25em;
+}
+
 .people ul {
   column-width: 25ch;
 }
@@ -536,10 +545,11 @@ input.switch:checked ~ label:after {
 }
 
 .people .participant {
+  display: inline-block;
   min-width: 10rem;
   margin-right: 1rem;
   margin-bottom: 1rem;
-  break-inside: avoid;
+  break-inside: avoid-column;
 }
 
 .people .participant {
@@ -561,12 +571,25 @@ input.switch:checked ~ label:after {
   margin: 1rem 0;
 }
 
+.person-back-button {
+  border: none;
+  background: none;
+  font-size: .8em;
+  cursor: pointer;
+}
+
 .person .person-image img {
   max-width: 10rem;
   padding: 0.3rem;
   margin: 0 0.5rem 0.5rem 0;
   box-shadow: 0px 2px 2px 0px var(--shadow-014),
     0px 3px 1px -2px var(--shadow-012), 0px 1px 5px 0px var(--shadow-02);
+}
+
+.person-tags {
+  font-size: 0.9em;
+  color: var(--program-tags-fg);
+  margin-bottom: .24rem;
 }
 
 .person .person-links {

--- a/src/ProgramData.js
+++ b/src/ProgramData.js
@@ -4,7 +4,7 @@ import { Format } from "./utils/Format";
 import { Temporal } from "@js-temporal/polyfill";
 import { LocalTime } from "./utils/LocalTime";
 
-// 
+//
 
 /**
  * Class for processing program and people data.
@@ -350,6 +350,8 @@ export class ProgramData {
     this.addProgramParticipantDetails(program, people);
     const locations = this.processLocations(program);
     const tags = this.processTags(program, configData.TAGS);
+    const personTags = this.processTags(people, configData.PEOPLE.TAGS);
+    console.log(personTags);
     LocalTime.checkTimezonesDiffer(program);
 
     return {
@@ -357,6 +359,7 @@ export class ProgramData {
       people: people,
       locations: locations,
       tags: tags,
+      personTags: personTags,
     };
   }
 

--- a/src/components/People.js
+++ b/src/components/People.js
@@ -1,11 +1,13 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { useStoreState, useStoreActions } from "easy-peasy";
+import TagSelectors from "./TagSelectors";
 import Participant from "./Participant";
 import configData from "../config.json";
 
 const People = () => {
   const people = useStoreState((state) => state.people);
+  const personTags = useStoreState((state) => state.personTags);
   const showThumbnails = useStoreState((state) => state.showThumbnails);
   const setShowThumbnails = useStoreActions(
     (actions) => actions.setShowThumbnails
@@ -16,12 +18,27 @@ const People = () => {
   );
 
   const [search, setSearch] = useState("");
-  //console.log(people);
+  const [selTags, setSelTags] = useState({});
 
   // Make a copy of people array, and apply filtering and sorting.
   let displayPeople = [...people];
   if (sortByFullName)
     displayPeople.sort((a, b) => a.name.localeCompare(b.name));
+  // Filter by each tag dropdown.
+  for (const tagType in selTags) {
+    if (selTags[tagType].length) {
+      displayPeople = displayPeople.filter((item) => {
+        if (item.hasOwnProperty("tags")) {
+          for (const tag of item.tags) {
+            for (const selected of selTags[tagType]) {
+              if (selected.value === tag.value) return true;
+            }
+          }
+        }
+        return false;
+      });
+    }
+  }
   const term = search.trim().toLowerCase();
   if (term.length > 0)
     displayPeople = displayPeople.filter((person) => {
@@ -95,6 +112,12 @@ const People = () => {
       <div className="people-settings">
         {thumbnailsCheckbox}
         {sortCheckbox}
+        <TagSelectors
+          tags={personTags}
+          selTags={selTags}
+          setSelTags={setSelTags}
+          tagConfig={configData.PEOPLE.TAGS}
+        />
         {searchInput}
       </div>
       <ul>{rows}</ul>

--- a/src/components/Person.js
+++ b/src/components/Person.js
@@ -1,12 +1,16 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import { useStoreState } from "easy-peasy";
 import { useParams } from "react-router-dom";
 import DOMPurify from "dompurify";
+import { MdOutlineArrowBackIos } from "react-icons/md";
 import PersonLinks from "./PersonLinks";
 import ProgramList from "./ProgramList";
+import Tag from "./Tag";
 import configData from "../config.json";
 
 const Person = () => {
+  const navigate = useNavigate();
   const program = useStoreState((state) => state.program);
   const people = useStoreState((state) => state.people);
   const params = useParams();
@@ -31,12 +35,26 @@ const Person = () => {
     }
     return false;
   });
+
+  const getPersonTags = (person) => {
+    if (!person.hasOwnProperty("tags") || person.tags.length === 0) return "";
+    const tags = [];
+    for (const tag of person.tags) {
+      tags.push(<Tag key={tag.value} tag={tag.label} />);
+    }
+    return <div className="person-tags">{tags}</div>;
+  };
+
   return (
     <div className="person">
       <h2 className="person-name">
+        <button className="person-back-button" onClick={() => navigate(-1)}>
+          <MdOutlineArrowBackIos />
+        </button>{" "}
         <span className="person-title">{configData.PEOPLE.PERSON_HEADER}</span>
         {person.name}
       </h2>
+      {getPersonTags(person)}
       <div className="person-image">{img}</div>
       <div
         className="person-bio"

--- a/src/components/PersonLinks.js
+++ b/src/components/PersonLinks.js
@@ -22,7 +22,7 @@ const PersonLinks = ({ person }) => {
     switch (type) {
       case "twitter":
         return <FaTwitter />;
-      case "fa":
+      case "fb":
       case "facebook":
         return <FaFacebook />;
       case "instagram":

--- a/src/config.json
+++ b/src/config.json
@@ -2,8 +2,8 @@
   "BASE_PATH": "/",
   "APP_ID": "O2021",
   "APP_TITLE": "ConClár Programme Guide",
-  "PROGRAM_DATA_URL": "https://zambia.octocon.com/konOpasData.jsonp",
-  "PEOPLE_DATA_URL": "https://zambia.octocon.com/konOpasData.jsonp",
+  "PROGRAM_DATA_URL": "schedule_tag.json",
+  "PEOPLE_DATA_URL": "participants_tag.json",
   "FETCH_OPTIONS": {
     "cache": "reload",
     "credentials": "omit",
@@ -11,7 +11,7 @@
       "Origin": "http://example.com"
     }
   },
-  "TIMEZONE": "Europe/Dublin",
+  "TIMEZONE": "America/Chicago",
   "INTERACTIVE": true,
   "HEADER": {
     "IMG_SRC": "",
@@ -120,8 +120,7 @@
       "SEARCHABLE": false,
       "HIDE": false,
       "SEPARATE": [
-      ],
-      "FORMAT_AS_TAG": false
+      ]
     },
     "SEARCH": {
       "SHOW_SEARCH": true,

--- a/src/config.json
+++ b/src/config.json
@@ -115,6 +115,14 @@
       "SHOW_CHECKBOX": true,
       "CHECKBOX_LABEL": "Sort by full name"
     },
+    "TAGS": {
+      "PLACEHOLDER": "Select tags",
+      "SEARCHABLE": false,
+      "HIDE": false,
+      "SEPARATE": [
+      ],
+      "FORMAT_AS_TAG": false
+    },
     "SEARCH": {
       "SHOW_SEARCH": true,
       "SEARCH_LABEL": "Search people"

--- a/src/model.js
+++ b/src/model.js
@@ -9,6 +9,7 @@ const model = {
   people: [],
   locations: [],
   tags: [],
+  personTags: [],
   lastFetchTime: null,
   timeSinceLastFetch: null,
   showLocalTime: LocalTime.getStoredLocalTime(),
@@ -33,6 +34,7 @@ const model = {
     state.people = data.people;
     state.locations = data.locations;
     state.tags = data.tags;
+    state.personTags = data.personTags;
   }),
   resetLastFetchTime: action((state) => {
     state.lastFetchTime = new Date().getTime();


### PR DESCRIPTION
Have added tags for people as follows:
- Added tags to people file format (tags take same format as program tags).
- Added TAG options under PEOPLE in config. Takes same format as program tag settings, except doesn't have DAY_TAG options because that would make no sense.
- Added TagSelector component to People page, and filter people by tags.
- Added tag listing under name on Person page.
- Added CSS settings for formatting person tags.

Not related to tags, but have added back button to person page, as there wasn't a clear route back previously, and pressing browser back button was a little clunky.