### PR TITLE
Change search boxes to search input type. Update styling.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -31,6 +31,7 @@
   --checkbox-switch-bg: white;
   --checkbox-selected-bg: green;
   --checkbox-unselected-bg: red;
+  --search-border: hsl(0, 0%, 80%);
   --program-item-chevron-collapsed: #ccc;
   --program-item-chevron-expanded: #bbe;
   --program-time-convention-message: grey;
@@ -305,9 +306,17 @@ input.switch:checked ~ label:after {
   white-space: nowrap;
 }
 
-.filter-search {
+.filter-search,
+.people-search {
   max-width: 30ch;
   margin: auto 0.25em;
+}
+
+.filter-search input,
+.people-search input {
+  min-height: 38px;
+  border: 1px var(--search-border) solid;
+  border-radius: 4px;
 }
 
 .filter-expand {

--- a/src/components/FilterableProgram.js
+++ b/src/components/FilterableProgram.js
@@ -118,7 +118,7 @@ const FilterableProgram = () => {
           />
           <div className="filter-search">
             <input
-              type="text"
+              type="search"
               placeholder={configData.PROGRAM.SEARCH.SEARCH_LABEL}
               value={search}
               onChange={(e) => setSearch(e.target.value)}

--- a/src/components/People.js
+++ b/src/components/People.js
@@ -106,7 +106,7 @@ const People = () => {
   const searchInput = configData.PEOPLE.SEARCH.SHOW_SEARCH ? (
     <div className="people-search">
       <input
-        type="text"
+        type="search"
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         placeholder={configData.PEOPLE.SEARCH.SEARCH_LABEL}


### PR DESCRIPTION
This change tweaks the search box as follows:
- Change input type from "text" to "search". In most browsers, they are displayed the same, but some browsers benefit from knowing it's a search box.
- Tweak search CSS to make it more like tag selectors.