### PR TITLE
Show time zone after time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The main place customisations go is the `src/config.json` file. Settings current
   - `"credentials": "omit"` - Use if source is not using a certificate from a recognised authority, e.g. a self signed cert.
   - `"headers": { "Origin": "http://example.com" }` - Headers sent in the fetch. Origin may be required for Cross Origin Resource Sharing (CORS).
 - `TIMEZONE`: The name of the timezone where your convention takes place. Viewers outside convention timezone will see times in convention time, and their local time below it.
+- `TIMEZONE_CODE`: The short code for the convention timezone. Set to blank to get browser code for timezone (not recommended, as it may not select the most elegant short code).
 - `INTERACTIVE`: Set to `false` to get a non-interactive, expanded view of the schedule. The info page is also included, but not the participant list, individual participant pages, or individual item pages (regardless of the `PERMALINK.SHOW_PERMALINK` setting).
 - `HEADER`: Add an optional image to the header of the pages.
 - `HEADER.IMG_SRC`: Set to the image filename to display. May be a file in the public directory. Leave blank for no image.
@@ -122,6 +123,10 @@ The main place customisations go is the `src/config.json` file. Settings current
 - `SETTINGS.SHOW_LOCAL_TIME.NEVER_LABEL`: Label for "Never show" option.
 - `SETTINGS.SHOW_LOCAL_TIME.DIFFERS_LABEL`: Label for "Display if different from Convention timezone".
 - `SETTINGS.SHOW_LOCAL_TIME.ALWAYS_LABEL`: Label for "Always display" option.
+- `SETTINGS.SHOW_TIMEZONE.LABEL`: Label for Show timezone after times option group.
+- `SETTINGS.SHOW_TIMEZONE.NEVER_LABEL`: Label for "Never show" option.
+- `SETTINGS.SHOW_TIMEZONE.IF_LOCAL_LABEL`: Label for "Show timezone if local time shown".
+- `SETTINGS.SHOW_TIMEZONE.ALWAYS_LABEL`: Label for "Always show" option.
 - `SETTINGS.SELECT_TIMEZONE.LABEL`: Lable for select timezone group,
 - `SETTINGS.SELECT_TIMEZONE.BROWSER_DEFAULT_LABEL`: Label to use browser default timezone (will have name of timezone appended).
 - `SETTINGS.SELECT_TIMEZONE.SELECT_LABEL`: Label to select explicit timezone.

--- a/src/App.css
+++ b/src/App.css
@@ -386,9 +386,28 @@ input.switch:checked ~ label:after {
 }
 
 .timeslot-time {
-  min-width: 8ch;
+  min-width: 9ch;
   vertical-align: top;
   flex-grow: 0;
+}
+
+.timeslot-wide {
+  min-width: 12ch;
+}
+
+.time-convention {
+  font-weight: bold;
+}
+
+.time-local {
+  font-style: italic;
+  font-size: 0.9em;
+  padding-left: 0.2em;
+  max-width: 9ch;
+}
+
+.timeslot-wide .time-local {
+  max-width: 12ch;
 }
 
 .timeslot-items {
@@ -530,17 +549,6 @@ input.switch:checked ~ label:after {
   padding: 0.5rem;
   border-radius: 0.5rem;
   overflow: auto;
-}
-
-.time-convention {
-  font-weight: bold;
-}
-
-.time-local {
-  font-style: italic;
-  font-size: 0.9em;
-  padding-left: 0.2em;
-  max-width: 10ch;
 }
 
 /*

--- a/src/ProgramData.js
+++ b/src/ProgramData.js
@@ -62,10 +62,10 @@ export class ProgramData {
    * @returns {array}
    */
   static processProgramData(program) {
-    const utcTimezone = Temporal.TimeZone.from("UTC");
+    const utcTimeZone = Temporal.TimeZone.from("UTC");
     program.map((item) => {
       const startTime = this.processDateAndTime(item);
-      item.dateAndTime = startTime.withTimeZone(utcTimezone);
+      item.dateAndTime = startTime.withTimeZone(utcTimeZone);
       return item;
     });
     program.sort((a, b) => {
@@ -351,7 +351,7 @@ export class ProgramData {
     const locations = this.processLocations(program);
     const tags = this.processTags(program, configData.TAGS);
     const personTags = this.processTags(people, configData.PEOPLE.TAGS);
-    LocalTime.checkTimezonesDiffer(program);
+    LocalTime.checkTimeZonesDiffer(program);
 
     return {
       program: program,

--- a/src/components/ProgramList.js
+++ b/src/components/ProgramList.js
@@ -8,7 +8,7 @@ import configData from "../config.json";
 const ProgramList = ({ program, forceExpanded }) => {
   const showLocalTime = useStoreState((state) => state.showLocalTime);
 
-  LocalTime.checkTimezonesDiffer(program);
+  LocalTime.checkTimeZonesDiffer(program);
 
   const rows = [];
   let itemRows = [];
@@ -23,7 +23,7 @@ const ProgramList = ({ program, forceExpanded }) => {
   }
   program.forEach((item) => {
     const itemDate = item.dateAndTime
-      .withTimeZone(LocalTime.conventionTimezone)
+      .withTimeZone(LocalTime.conventionTimeZone)
       .round({ smallestUnit: "day", roundingMode: "floor" });
 
     if (curDate === null || !itemDate.equals(curDate)) {
@@ -64,7 +64,7 @@ const ProgramList = ({ program, forceExpanded }) => {
       <div className="time-local-message">
         {configData.LOCAL_TIME.NOTICE.replace(
           "@timezone",
-          LocalTime.localTimezone
+          LocalTime.localTimeZone
         )}
       </div>
     ) : (

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -1,10 +1,10 @@
 import configData from "../config.json";
 import { useStoreState, useStoreActions } from "easy-peasy";
 import { Temporal } from "@js-temporal/polyfill";
-import TimezoneSelect from "react-timezone-select";
+import TimeZoneSelect from "react-timezone-select";
 
 const Settings = () => {
-  const defaultTimezone = Temporal.Now.timeZone().toString();
+  const defaultTimeZone = Temporal.Now.timeZone().toString();
 
   const show12HourTime = useStoreState((state) => state.show12HourTime);
   const setShow12HourTime = useStoreActions(
@@ -16,19 +16,22 @@ const Settings = () => {
     (actions) => actions.setShowLocalTime
   );
 
-  const useTimezone = useStoreState((state) => state.useTimezone);
-  const setUseTimezone = useStoreActions((actions) => actions.setUseTimezone);
+  const showTimeZone = useStoreState((state) => state.showTimeZone);
+  const setShowTimeZone = useStoreActions((actions) => actions.setShowTimeZone);
 
-  const selectedTimezone = useStoreState((state) => state.selectedTimezone);
-  const setSelectedTimezone = useStoreActions(
-    (actions) => actions.setSelectedTimezone
+  const useTimeZone = useStoreState((state) => state.useTimeZone);
+  const setUseTimeZone = useStoreActions((actions) => actions.setUseTimeZone);
+
+  const selectedTimeZone = useStoreState((state) => state.selectedTimeZone);
+  const setSelectedTimeZone = useStoreActions(
+    (actions) => actions.setSelectedTimeZone
   );
 
-  const timezoneSelect = useTimezone ? (
+  const timezoneSelect = useTimeZone ? (
     <div>
-      <TimezoneSelect
-        value={selectedTimezone}
-        onChange={(e) => setSelectedTimezone(e.value)}
+      <TimeZoneSelect
+        value={selectedTimeZone}
+        onChange={(e) => setSelectedTimeZone(e.value)}
         labelStyle="abbrev"
       />
     </div>
@@ -99,6 +102,41 @@ const Settings = () => {
           </label>
         </div>
       </div>
+      <div className="settings-group select-show-timezone">
+        <div className="settings-head">{ configData.SETTINGS.SHOW_TIMEZONE.LABEL }</div>
+        <div className="settings-radio">
+          <label>
+            <input
+              type="radio"
+              value="never"
+              name="show_timezone"
+              checked={showTimeZone === "never"}
+              onChange={(e) => setShowTimeZone(e.target.value)}
+            />
+            { configData.SETTINGS.SHOW_TIMEZONE.NEVER_LABEL }
+          </label>
+          <label>
+            <input
+              type="radio"
+              value="if_local"
+              name="show_timezone"
+              checked={showTimeZone === "if_local"}
+              onChange={(e) => setShowTimeZone(e.target.value)}
+            />
+            { configData.SETTINGS.SHOW_TIMEZONE.IF_LOCAL_LABEL }
+          </label>
+          <label>
+            <input
+              type="radio"
+              value="always"
+              name="show_timezone"
+              checked={showTimeZone === "always"}
+              onChange={(e) => setShowTimeZone(e.target.value)}
+            />
+            { configData.SETTINGS.SHOW_TIMEZONE.ALWAYS_LABEL }
+          </label>
+        </div>
+      </div>
       <div className="settings-group select-timezone">
         <div className="settings-head">{ configData.SETTINGS.SELECT_TIMEZONE.LABEL }</div>
         <div className="settings-radio">
@@ -107,18 +145,18 @@ const Settings = () => {
               type="radio"
               value="default"
               name="method"
-              checked={!useTimezone}
-              onChange={(e) => setUseTimezone(e.target.value === "select")}
+              checked={!useTimeZone}
+              onChange={(e) => setUseTimeZone(e.target.value === "select")}
             />
-            { configData.SETTINGS.SELECT_TIMEZONE.BROWSER_DEFAULT_LABEL } {defaultTimezone}
+            { configData.SETTINGS.SELECT_TIMEZONE.BROWSER_DEFAULT_LABEL } {defaultTimeZone}
           </label>
           <label>
             <input
               type="radio"
               value="select"
               name="method"
-              checked={useTimezone}
-              onChange={(e) => setUseTimezone(e.target.value === "select")}
+              checked={useTimeZone}
+              onChange={(e) => setUseTimeZone(e.target.value === "select")}
             />
             { configData.SETTINGS.SELECT_TIMEZONE.SELECT_LABEL }
           </label>

--- a/src/components/TimeSlot.js
+++ b/src/components/TimeSlot.js
@@ -6,24 +6,24 @@ import { LocalTime } from "../utils/LocalTime";
 const TimeSlot = ({ dateAndTime, items, forceExpanded }) => {
   const showLocalTime = useStoreState((state) => state.showLocalTime);
   const show12HourTime = useStoreState((state) => state.show12HourTime);
+  const timeZoneIsShown = useStoreState((state) => state.timeZoneIsShown);
   if (!dateAndTime) return "";
   const conTime = (
     <div className="time-convention">
-      {LocalTime.formatTimeInConventionTimeZone(dateAndTime, show12HourTime)}
+      {LocalTime.formatTimeInConventionTimeZone(dateAndTime, show12HourTime, timeZoneIsShown)}
     </div>
   );
   const localTime =
     showLocalTime === "always" ||
     (showLocalTime === "differs" && LocalTime.timezonesDiffer) ? (
       <div className="time-local">
-        {LocalTime.formatTimeInLocalTimeZone(
-          dateAndTime,
-          show12HourTime
-        )}
+        {LocalTime.formatTimeInLocalTimeZone(dateAndTime, show12HourTime, timeZoneIsShown)}
       </div>
     ) : (
       ""
     );
+  const timeSlotClass =
+    "timeslot-time" + (timeZoneIsShown ? " timeslot-wide" : "");
   const rows = [];
   items.forEach((item) => {
     rows.push(
@@ -33,7 +33,7 @@ const TimeSlot = ({ dateAndTime, items, forceExpanded }) => {
 
   return (
     <div id={dateAndTime.toString()} className="timeslot">
-      <div className="timeslot-time">
+      <div className={timeSlotClass}>
         {conTime}
         {localTime}
       </div>

--- a/src/config.json
+++ b/src/config.json
@@ -12,6 +12,7 @@
     }
   },
   "TIMEZONE": "Europe/Dublin",
+  "TIMEZONECODE": "WEST",
   "INTERACTIVE": true,
   "HEADER": {
     "IMG_SRC": "",
@@ -156,6 +157,12 @@
       "LABEL": "Show local time",
       "NEVER_LABEL": "Never display",
       "DIFFERS_LABEL": "Display if differs from convention time",
+      "ALWAYS_LABEL": "Always show"
+    },
+    "SHOW_TIMEZONE": {
+      "LABEL": "Show timezone after times",
+      "NEVER_LABEL": "Never show",
+      "IF_LOCAL_LABEL": "Show timezone if local time shown",
       "ALWAYS_LABEL": "Always show"
     },
     "SELECT_TIMEZONE": {

--- a/src/model.js
+++ b/src/model.js
@@ -14,8 +14,9 @@ const model = {
   timeSinceLastFetch: null,
   showLocalTime: LocalTime.getStoredLocalTime(),
   show12HourTime: LocalTime.getStoredTwelveHourTime(),
-  useTimezone: LocalTime.getStoredUseTimezone(),
-  selectedTimezone: LocalTime.getStoredSelectedTimezone(),
+  showTimeZone: LocalTime.getStoredShowTimeZone(),
+  useTimeZone: LocalTime.getStoredUseTimeZone(),
+  selectedTimeZone: LocalTime.getStoredSelectedTimeZone(),
   showPastItems: LocalTime.getStoredPastItems(),
   expandedItems: [],
   mySelections: ProgramSelection.getAllSelections(),
@@ -58,13 +59,17 @@ const model = {
     state.show12HourTime = show12HourTime;
     LocalTime.setStoredTwelveHourTime(show12HourTime);
   }),
-  setUseTimezone: action((state, useTimezone) => {
-    state.useTimezone = useTimezone;
-    LocalTime.setStoredUseTimezone(useTimezone);
+  setShowTimeZone: action((state, showTimeZone) => {
+    state.showTimeZone = showTimeZone;
+    LocalTime.setStoredShowTimeZone(showTimeZone);
   }),
-  setSelectedTimezone: action((state, selectedTimezone) => {
-    state.selectedTimezone = selectedTimezone;
-    LocalTime.setStoredSelectedTimezone(selectedTimezone);
+  setUseTimeZone: action((state, useTimeZone) => {
+    state.useTimeZone = useTimeZone;
+    LocalTime.setStoredUseTimeZone(useTimeZone);
+  }),
+  setSelectedTimeZone: action((state, selectedTimeZone) => {
+    state.selectedTimeZone = selectedTimeZone;
+    LocalTime.setStoredSelectedTimeZone(selectedTimeZone);
   }),
   setShowPastItems: action((state, showPastItems) => {
     state.showPastItems = showPastItems;
@@ -148,6 +153,15 @@ const model = {
   // Computed.
   timeToNextFetch: computed((state) => {
     return configData.TIMER.FETCH_INTERVAL_MINS * 60 - state.timeSinceLastFetch;
+  }),
+  timeZoneIsShown: computed((state) => {
+    return (
+      state.showTimeZone === "always" ||
+      (state.showTimeZone === "if_local" &&
+        (state.showLocalTime === "always" ||
+          (state.showLocalTime === "differs" &&
+            LocalTime.timezonesDiffer)))
+    );
   }),
   programIsFiltered: computed((state) => {
     if (state.programSelectedLocations.length > 0) return true;

--- a/src/utils/LocalTime.js
+++ b/src/utils/LocalTime.js
@@ -3,22 +3,23 @@ import configData from "../config.json";
 
 // Class containing finctions for formatting values for ConClár.
 export class LocalTime {
-  static conventionTimezone = new Temporal.TimeZone(configData.TIMEZONE);
-  static localTimezone = null;
+  static conventionTimeZone = new Temporal.TimeZone(configData.TIMEZONE);
+  static localTimeZone = null;
   static timezonesDiffer = false;
+  static timeZoneIsShown = false;
 
   // Initialise local timezone.
   static {
-    this.getLocalTimezone();
+    this.getLocalTimeZone();
   }
 
-  static getLocalTimezone() {
+  static getLocalTimeZone() {
     // Check if using browser default timezone, or user selected.
-    const useTimezone = this.getStoredUseTimezone();
-    const timezoneName = useTimezone
-      ? this.getStoredSelectedTimezone()
+    const useTimeZone = this.getStoredUseTimeZone();
+    const timezoneName = useTimeZone
+      ? this.getStoredSelectedTimeZone()
       : Intl.DateTimeFormat().resolvedOptions().timeZone;
-    this.localTimezone = new Temporal.TimeZone(timezoneName);
+    this.localTimeZone = new Temporal.TimeZone(timezoneName);
   }
 
   static get localTimeClass() {
@@ -42,43 +43,61 @@ export class LocalTime {
     return "twelve_hour_time";
   }
 
-  static getStoredUseTimezone() {
-    const storedUseTimezone = localStorage.getItem(this.useTimezoneClass);
-    if (storedUseTimezone === null || storedUseTimezone === "") {
+  static getStoredShowTimeZone() {
+    const storedShowTimeZone = localStorage.getItem(this.showTimeZoneClass);
+    if (["never", "if_local", "always"].includes(storedShowTimeZone))
+      return storedShowTimeZone;
+    if (storedShowTimeZone === false || storedShowTimeZone === "false") {
+      return "never";
+    }
+    return "if_local";
+  }
+
+  static setStoredShowTimeZone(showTimeZone) {
+    localStorage.setItem(this.showTimeZoneClass, showTimeZone);
+    this.getLocalTimeZone();
+  }
+
+  static get showTimeZoneClass() {
+    return "show_timezone";
+  }
+
+  static getStoredUseTimeZone() {
+    const storedUseTimeZone = localStorage.getItem(this.useTimeZoneClass);
+    if (storedUseTimeZone === null || storedUseTimeZone === "") {
       return false;
     }
-    return storedUseTimezone === "default" ? false : true;
+    return storedUseTimeZone === "default" ? false : true;
   }
 
-  static setStoredUseTimezone(useTimezone) {
+  static setStoredUseTimeZone(useTimeZone) {
     localStorage.setItem(
-      this.useTimezoneClass,
-      useTimezone ? "select" : "default"
+      this.useTimeZoneClass,
+      useTimeZone ? "select" : "default"
     );
-    this.getLocalTimezone();
-
+    this.getLocalTimeZone();
   }
 
-  static get useTimezoneClass() {
+  static get useTimeZoneClass() {
     return "use_timezone";
   }
 
-  static getStoredSelectedTimezone() {
-    const storedSelectedTimezone = localStorage.getItem(
-      this.selectedTimezoneClass
+  static getStoredSelectedTimeZone() {
+    const storedSelectedTimeZone = localStorage.getItem(
+      this.selectedTimeZoneClass
     );
-    if (storedSelectedTimezone === null || storedSelectedTimezone === "") {
+    if (storedSelectedTimeZone === null || storedSelectedTimeZone === "") {
       return Temporal.Now.timeZone().toString();
     }
-    return storedSelectedTimezone;
+    return storedSelectedTimeZone;
   }
 
-  static setStoredSelectedTimezone(timezone) {
-    localStorage.setItem(this.selectedTimezoneClass, timezone);
-    this.getLocalTimezone();
+  static setStoredSelectedTimeZone(timezone) {
+    localStorage.setItem(this.selectedTimeZoneClass, timezone);
+    this.getLocalTimeZone();
   }
 
-  static get selectedTimezoneClass() {
+  static get selectedTimeZoneClass() {
     return "selected_timezone";
   }
 
@@ -130,11 +149,11 @@ export class LocalTime {
    * @param {Temporal.ZonedDateTime} dateAndTime
    * @returns {bool}
    */
-  static checkTimezoneOffsetForDate(dateAndTime) {
+  static checkTimeZoneOffsetForDate(dateAndTime) {
     const instant = Temporal.Instant.from(dateAndTime);
-    const localOffset = this.localTimezone.getOffsetNanosecondsFor(instant);
+    const localOffset = this.localTimeZone.getOffsetNanosecondsFor(instant);
     const conventionOffset =
-      this.conventionTimezone.getOffsetNanosecondsFor(instant);
+      this.conventionTimeZone.getOffsetNanosecondsFor(instant);
     if (localOffset !== conventionOffset) {
       return true;
     }
@@ -147,17 +166,17 @@ export class LocalTime {
    * @param {array} program
    * @returns {bool}
    */
-  static checkTimezonesDiffer(program) {
+  static checkTimeZonesDiffer(program) {
     if (program.length === 0) {
       this.timezonesDiffer = false;
       return false;
     }
-    if (this.checkTimezoneOffsetForDate(program[0].dateAndTime)) {
+    if (this.checkTimeZoneOffsetForDate(program[0].dateAndTime)) {
       this.timezonesDiffer = true;
       return true;
     }
     const [lastItem] = program.slice(-1);
-    if (this.checkTimezoneOffsetForDate(lastItem.dateAndTime)) {
+    if (this.checkTimeZoneOffsetForDate(lastItem.dateAndTime)) {
       this.timezonesDiffer = true;
       return true;
     }
@@ -165,8 +184,14 @@ export class LocalTime {
     return false;
   }
 
-  // Format time for 24 clock.
-  static formatTime(dateAndTime, ampm) {
+  /**
+   * Format time for 24 clock.
+   * @param {temporal.ZonedDateTime} dateAndTime The data and time to format.
+   * @param {bool} ampm If true, format as 12 hour clock.
+   * @param {bool} showTimeZone If true, include the short timezone code.
+   * @returns {string} The formatted time.
+   */
+  static formatTime(dateAndTime, ampm, showTimeZone = false) {
     let language = window.navigator.userLanguage || window.navigator.language;
     const options = ampm
       ? {
@@ -179,24 +204,51 @@ export class LocalTime {
           minute: "2-digit",
           hour12: false,
         };
-    return dateAndTime.toLocaleString(language, options);
+    if (
+      showTimeZone &&
+      configData.TIMEZONECODE.length > 0 &&
+      Temporal.TimeZone.from(dateAndTime) === this.conventionTimeZone
+    ) {
+      return (
+        dateAndTime.toLocaleString(language, options) +
+        " " +
+        configData.TIMEZONECODE
+      );
+    } else {
+      if (showTimeZone) options.timeZoneName = "short";
+      return dateAndTime.toLocaleString(language, options);
+    }
   }
 
-  // Format the time in the convention time zone. Currently this is not reformatted, but it may be in future.
-  static formatTimeInConventionTimeZone(dateAndTime, ampm) {
+  /**
+   * Format the time in the convention time zone.
+   * @param {Temporal.ZonedDateTime} dateAndTime The date and time to display.
+   * @param {bool} ampm If true, show 12 hour.
+   * @param {bool} showTimeZone  If true show the time zone code.
+   * @returns {string} The formatted time.
+   */
+  static formatTimeInConventionTimeZone(dateAndTime, ampm, showTimeZone) {
     return this.formatTime(
-      dateAndTime.withTimeZone(this.conventionTimezone),
-      ampm
+      dateAndTime.withTimeZone(this.conventionTimeZone),
+      ampm,
+      showTimeZone
     );
   }
 
-  static formatTimeInLocalTimeZone(dateAndTime, ampm) {
+  /**
+   * Format the time in the local time zone.
+   * @param {Temporal.ZonedDateTime} dateAndTime The date and time to display.
+   * @param {bool} ampm If true, show 12 hour.
+   * @param {bool} showTimeZone  If true show the time zone code.
+   * @returns {string} The formatted time.
+   */
+   static formatTimeInLocalTimeZone(dateAndTime, ampm, showTimeZone) {
     // Convert the program item time into local time.
-    const localDateAndTime = dateAndTime.withTimeZone(this.localTimezone);
-    const formattedTime = this.formatTime(localDateAndTime, ampm);
+    const localDateAndTime = dateAndTime.withTimeZone(this.localTimeZone);
+    const formattedTime = this.formatTime(localDateAndTime, ampm, showTimeZone);
     // Get the con and local dates with time stripped out.
     const conDate = Temporal.PlainDate.from(
-      dateAndTime.withTimeZone(this.conventionTimezone)
+      dateAndTime.withTimeZone(this.conventionTimeZone)
     );
     const localDate = Temporal.PlainDate.from(localDateAndTime);
     // Compare the dates without time to see if we're showing time on next or previous day, and if so attach label.
@@ -219,7 +271,7 @@ export class LocalTime {
   static formatDayNameInConventionTimeZone(dateAndTime) {
     let language = window.navigator.userLanguage || window.navigator.language;
     return dateAndTime
-      .withTimeZone(this.conventionTimezone)
+      .withTimeZone(this.conventionTimeZone)
       .toLocaleString(language, { weekday: "long" });
   }
 
@@ -231,7 +283,7 @@ export class LocalTime {
    */
   static formatISODateInConventionTimeZone(dateAndTime) {
     const language = window.navigator.userLanguage || window.navigator.language;
-    const conDate = dateAndTime.withTimeZone(this.conventionTimezone);
+    const conDate = dateAndTime.withTimeZone(this.conventionTimeZone);
     return (
       conDate.toLocaleString(language, { year: "numeric" }) +
       "-" +


### PR DESCRIPTION
Show time zone short label after times.
By default will only be shown when local time is displayed.
Added new setting to Settings page to select when to show timezone. Defaults to "Show timezone if local time shown".
Added new config option to let user change when to display timezone.
Added config options for new Settings page labels.

This should resolve #114. 