### PR TITLE
Revert moderator code. Fix links loop.

### DIFF
--- a/src/ProgramData.js
+++ b/src/ProgramData.js
@@ -118,11 +118,8 @@ export class ProgramData {
             (fullPerson) => fullPerson.id === item.people[index].id
           );
           //Moderator check before nuking the item person data.
-          if (
-            item.people[index].name.includes("(moderator)") ||
-            (item.people[index].hasOwnProperty("role") &&
-              item.people[index].role.toLowerCase === "moderator")
-          )
+          if (item.people[index].name.indexOf("(moderator)") > 0 || 
+              (item.people[index].hasOwnProperty("role") && item.people[index].role === "moderator"))
             item.moderator = item.people[index].id;
           if (fullPerson) {
             // Replace partial person with full person reference.

--- a/src/components/PersonLinks.js
+++ b/src/components/PersonLinks.js
@@ -56,9 +56,9 @@ const PersonLinks = ({ person }) => {
   // Loop through links, indexed by link type.
   for (const type in person.links) {
     // Don't add image links to link display.
-    if (type === "img" || type === "photo" || type === "img_256_url") break;
+    if (type === "img" || type === "photo" || type === "img_256_url") continue;
     // If link not fitting web url template, ignore.
-    if (!person.links[type].match(regex)) break;
+    if (!person.links[type].match(regex)) continue;
     // Look up the correct icon.
     const icon = getLinkIcon(type);
     // Add link HTML to array.


### PR DESCRIPTION
Revert the moderator code to the old code as the new didn't work.
In the link loop, change break to continue otherwise the loop stops and some links won't display.