### PR TITLE
CSS tweaks

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -32,10 +32,10 @@
   --checkbox-selected-bg: green;
   --checkbox-unselected-bg: red;
   --search-border: hsl(0, 0%, 80%);
-  --reset-button-bg: #5b6473; /*#525e73; #343c4b;*/
-  --reset-button-fg: #fff;
-  --add-all-button-bg: #5b6473; /*#525e73; #343c4b;*/
-  --add-all-button-fg: #fff;
+  --reset-button-bg: var(--navigation-button-current-bg);
+  --reset-button-fg: var(--navigation-button-current-fg);
+  --add-all-button-bg: var(--navigation-button-current-bg);
+  --add-all-button-fg: var(--navigation-button-current-fg);
   --program-item-chevron-collapsed: #ccc;
   --program-item-chevron-expanded: #bbe;
   --program-time-convention-message: grey;

--- a/src/App.css
+++ b/src/App.css
@@ -562,13 +562,17 @@ input.switch:checked ~ label:after {
 }
 
 .share-head {
-  margin-bottom: 0.5em;
+  margin-bottom: 0.5rem;
   font-weight: bold;
   font-size: 1.1em;
 }
 
 .share-body {
-  margin-bottom: 0.25em;
+  margin-bottom: 0.25rem;
+}
+
+.share-qr-code {
+  margin: 0.25rem;
 }
 
 /* ItemIDs page, showing shared items. */


### PR DESCRIPTION
- Added space around QR codes.
- Changed units for sharing section from em to rem.
- Changed colours of "Reset" and "Add all" buttons to use variables from navigation buttons. This keeps button colours consistent by default but makes it easy to customise if required.