### PR TITLE
Time slot cache

### DIFF
--- a/src/ProgramData.js
+++ b/src/ProgramData.js
@@ -66,6 +66,7 @@ export class ProgramData {
     program.map((item) => {
       const startTime = this.processDateAndTime(item);
       item.dateAndTime = startTime.withTimeZone(utcTimeZone);
+      item.timeSlot = LocalTime.getTimeSlot(item.dateAndTime);
       return item;
     });
     program.sort((a, b) => {

--- a/src/components/Day.js
+++ b/src/components/Day.js
@@ -1,19 +1,20 @@
 import PropTypes from "prop-types";
 import TimeSlot from "./TimeSlot";
 import { LocalTime } from "../utils/LocalTime";
-//import { IoSyncCircleOutline } from "react-icons/io5";
 
 const Day = ({ date, items, forceExpanded }) => {
   const day = LocalTime.formatDateForLocaleAsUTC(date);
   const rows = [];
   let itemRows = [];
+  let curTimeSlot = null;
   let curDateAndTime = null;
   items.forEach((item) => {
-    if (curDateAndTime === null || !item.dateAndTime.equals(curDateAndTime)) {
+    if (curTimeSlot === null || item.timeSlot !== curTimeSlot) {
       if (itemRows.length > 0) {
         rows.push(
           <TimeSlot
-            key={curDateAndTime.toString()}
+            key={curTimeSlot}
+            timeSlot={curTimeSlot}
             dateAndTime={curDateAndTime}
             items={itemRows}
             forceExpanded={forceExpanded}
@@ -21,13 +22,15 @@ const Day = ({ date, items, forceExpanded }) => {
         );
         itemRows = [];
       }
+      curTimeSlot = item.timeSlot;
       curDateAndTime = item.dateAndTime;
     }
     itemRows.push(item);
   });
   rows.push(
     <TimeSlot
-      key={curDateAndTime.toString()}
+      key={curTimeSlot}
+      timeSlot={curTimeSlot}
       dateAndTime={curDateAndTime}
       items={itemRows}
       forceExpanded={forceExpanded}

--- a/src/components/ProgramItem.js
+++ b/src/components/ProgramItem.js
@@ -1,3 +1,4 @@
+//import React, { useState, useImperativeHandle } from "react";
 import DOMPurify from "dompurify";
 import { useStoreState, useStoreActions } from "easy-peasy";
 import { Link } from "react-router-dom";
@@ -33,6 +34,12 @@ const ProgramItem = ({ item, forceExpanded }) => {
       } else expandItem(item.id);
     }
   }
+  // const [expanded, setExpanded] = useState(forceExpanded);
+  // function toggleExpanded() {
+  //   setExpanded(!expanded);
+  // }
+
+  // useImperativeHandle(expander, (expand) => setExpanded(expand));
 
   function handleSelected(event) {
     if (event.target.checked) addSelection(item.id);

--- a/src/components/ProgramItem.js
+++ b/src/components/ProgramItem.js
@@ -1,4 +1,3 @@
-//import React, { useState, useImperativeHandle } from "react";
 import DOMPurify from "dompurify";
 import { useStoreState, useStoreActions } from "easy-peasy";
 import { Link } from "react-router-dom";
@@ -34,12 +33,6 @@ const ProgramItem = ({ item, forceExpanded }) => {
       } else expandItem(item.id);
     }
   }
-  // const [expanded, setExpanded] = useState(forceExpanded);
-  // function toggleExpanded() {
-  //   setExpanded(!expanded);
-  // }
-
-  // useImperativeHandle(expander, (expand) => setExpanded(expand));
 
   function handleSelected(event) {
     if (event.target.checked) addSelection(item.id);

--- a/src/components/ProgramList.js
+++ b/src/components/ProgramList.js
@@ -1,3 +1,4 @@
+import React, { useEffect } from 'react';
 import PropTypes from "prop-types";
 import { useStoreState } from "easy-peasy";
 import { LocalTime } from "../utils/LocalTime";
@@ -10,6 +11,9 @@ const ProgramList = ({ program, forceExpanded }) => {
   const programDisplayLimit = useStoreState(
     (state) => state.programDisplayLimit
   );
+  useEffect(() => {
+    LocalTime.storeCachedTimes();
+  });
 
   LocalTime.checkTimeZonesDiffer(program);
 
@@ -83,7 +87,8 @@ const ProgramList = ({ program, forceExpanded }) => {
     ) : (
       ""
     );
-  return (
+
+    return (
     <div className="program-container">
       {conventionTime}
       {localTime}

--- a/src/components/TimeSlot.js
+++ b/src/components/TimeSlot.js
@@ -3,7 +3,7 @@ import { useStoreState } from "easy-peasy";
 import ProgramItem from "./ProgramItem";
 import { LocalTime } from "../utils/LocalTime";
 
-const TimeSlot = ({ dateAndTime, items, forceExpanded }) => {
+const TimeSlot = ({ timeSlot, dateAndTime, items, forceExpanded }) => {
   const showLocalTime = useStoreState((state) => state.showLocalTime);
   const show12HourTime = useStoreState((state) => state.show12HourTime);
   const timeZoneIsShown = useStoreState((state) => state.timeZoneIsShown);
@@ -11,6 +11,7 @@ const TimeSlot = ({ dateAndTime, items, forceExpanded }) => {
   const conTime = (
     <div className="time-convention">
       {LocalTime.formatTimeInConventionTimeZone(
+        timeSlot,
         dateAndTime,
         show12HourTime,
         timeZoneIsShown
@@ -22,6 +23,7 @@ const TimeSlot = ({ dateAndTime, items, forceExpanded }) => {
     (showLocalTime === "differs" && LocalTime.timezonesDiffer) ? (
       <div className="time-local">
         {LocalTime.formatTimeInLocalTimeZone(
+          timeSlot,
           dateAndTime,
           show12HourTime,
           timeZoneIsShown


### PR DESCRIPTION
- Added timeSlotCache to store numeric index of time slots.
- Added conventionTimeCache and localTimeCache to store rendered time text.
- Use numeric timeslot indexes whenever possible instead of dateAndTime.
- Store timeSlotCache, conventionTimeCache and localTimeCache in LocalStorage for reuse in later sessions.

These changes have yielded a minor performance improvement.