### PR TITLE
Make date and timeslot labels sticky

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -376,11 +376,19 @@ input.switch:checked ~ label:after {
 }
 
 .date-heading {
+  position: sticky;
+  top: 0;
   font-size: 1.5rem;
   font-weight: bold;
-  margin-top: 1rem;
+  margin-top: 0rem;
   margin-bottom: 0.5rem;
+  padding-top: 1rem;
   border-bottom: 1px solid var(--program-date-line);
+  background-color: var(--main-bg);
+}
+
+.debug-mode .date-heading {
+  padding-top: 3rem;
 }
 
 .timeslot {
@@ -397,6 +405,17 @@ input.switch:checked ~ label:after {
 
 .timeslot-wide {
   min-width: 12ch;
+}
+
+.time-wrapper {
+  position: sticky;
+  top: 3rem;
+  z-index: -1;
+}
+
+.debug-mode .time-wrapper {
+  position: sticky;
+  top: 5rem;
 }
 
 .time-convention {

--- a/src/components/Day.js
+++ b/src/components/Day.js
@@ -38,7 +38,7 @@ const Day = ({ date, items, forceExpanded }) => {
   );
 
   return (
-    <div id={day} className="date">
+    <div className="date">
       <div className="date-heading">{day}</div>
       <div className="date-items">{rows}</div>
     </div>

--- a/src/components/TimeSlot.js
+++ b/src/components/TimeSlot.js
@@ -44,8 +44,10 @@ const TimeSlot = ({ timeSlot, dateAndTime, items, forceExpanded }) => {
   return (
     <div id={dateAndTime.toString()} className="timeslot">
       <div className={timeSlotClass}>
-        {conTime}
-        {localTime}
+        <div className="time-wrapper">
+          {conTime}
+          {localTime}
+        </div>
       </div>
       <div className="timeslot-items">{rows}</div>
     </div>


### PR DESCRIPTION
- Add `position: sticky` to date and timeslot labels so the date and time of the currently viewed item is easily visible.
- Add background colour to date heading, so it will cover items scrolling under it.
- Added time-wrapper `div` around times so they can be themed as a block.
- Added `z-order: -1` to time-wrapper header so it scrolls beneath date header.

Unrelated change to remove id from date tag, as it contains spaces, which aren't allowed in IDs, and it isn't actually used in the application.