### PR TITLE
Changes to add dark mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,15 @@ The main place customisations go is the `src/config.json` file. Settings current
 - `SETTINGS.SHOW_TIMEZONE.NEVER_LABEL`: Label for "Never show" option.
 - `SETTINGS.SHOW_TIMEZONE.IF_LOCAL_LABEL`: Label for "Show timezone if local time shown".
 - `SETTINGS.SHOW_TIMEZONE.ALWAYS_LABEL`: Label for "Always show" option.
-- `SETTINGS.SELECT_TIMEZONE.LABEL`: Lable for select timezone group,
+- `SETTINGS.SELECT_TIMEZONE.LABEL`: Label for select timezone group,
 - `SETTINGS.SELECT_TIMEZONE.BROWSER_DEFAULT_LABEL`: Label to use browser default timezone (will have name of timezone appended).
 - `SETTINGS.SELECT_TIMEZONE.SELECT_LABEL`: Label to select explicit timezone.
+- `SETTINGS.DARK_MODE.LABEL`: Label for dark mode settings group.
+- `SETTINGS.DARK_MODE.BROWSER_DEFAULT_LABEL`: Label for default browser dark mode preference.
+- `SETTINGS.DARK_MODE.BROWSER_LIGHT_LABEL`: Label to indicate browser is currently in light mode.
+- `SETTINGS.DARK_MODE.BROWSER_DARK_LABEL`: Label to indicate browser is currently in dark mode.
+- `SETTINGS.DARK_MODE.LIGHT_MODE_LABEL`: Label for forcing light mode.
+- `SETTINGS.DARK_MODE.DARK_MODE_LABEL`: Label for forcing dark mode.
 - `INFORMATION.MARKDOWN_URL`: The address of the markdown file containing additional information about the convention.
 - `INFORMATION.LOADING_MESSAGE`: Text to show while Markdown file is loading (usually never seen).
 - `FOOTER.SITE_NOTE_MARKDOWN`: General note displayed in the footer of the page. May use Markdown for encoding of links, emphesis, etc.

--- a/src/App.css
+++ b/src/App.css
@@ -31,6 +31,13 @@
   --checkbox-switch-bg: white;
   --checkbox-selected-bg: green;
   --checkbox-unselected-bg: red;
+  --filter-bg: var(--main-bg);
+  --filter-fg: var(--main-fg);
+  --filter-border: var(--search-border);
+  --filter-select-bg: #bbe;
+  --filter-select-fg: #000;
+  --search-bg: var(--main-bg);
+  --search-fg: var(--main-fg);
   --search-border: hsl(0, 0%, 80%);
   --reset-button-bg: var(--navigation-button-current-bg);
   --reset-button-fg: var(--navigation-button-current-fg);
@@ -301,6 +308,47 @@ input.switch:checked ~ label:after {
   max-width: 50ch;
 }
 
+.filter-container .filter-select__control {
+  background-color: var(--filter-bg);
+  color: var(--filter-fg);
+  border: 1px var(--filter-border) solid;
+  border-radius: 4px;
+}
+
+.filter-container .filter-select__control--is-focused {
+  background-color: var(--filter-bg);
+  color: var(--filter-fg);
+}
+
+.filter-container .filter-select__menu {
+  background-color: var(--filter-bg);
+  color: var(--filter-fg);
+  border: 1px var(--filter-border) solid;
+  border-radius: 4px;
+}
+
+.filter-container .filter-select__option {
+  background-color: var(--filter-bg);
+  color: var(--filter-fg);
+}
+
+.filter-container .filter-select__option--is-focused {
+  background-color: var(--filter-select-bg);
+  color: var(--filter-select-fg);
+}
+
+.filter-container .filter-select__indicator-separator {
+  background-color: var(--filter-bg);
+  color: var(--filter-fg);
+}
+
+.filter-container .filter-select__input-container,
+.filter-container .filter-select__placeholder,
+.filter-container .filter-select__single-value {
+  background-color: var(--filter-bg);
+  color: var(--filter-fg);
+}
+
 .stack {
   flex-basis: 0;
   flex-grow: 2;
@@ -321,6 +369,8 @@ input.switch:checked ~ label:after {
 .filter-search input,
 .people-search input {
   min-height: 38px;
+  background-color: var(--search-bg);
+  color: var(--search-fg);
   border: 1px var(--search-border) solid;
   border-radius: 4px;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,6 @@ import "./App.css";
 const store = createStore(model);
 
 const App = () => {
-
   return (
     <StoreProvider store={store}>
       <AppRoutes />

--- a/src/components/AppRoutes.js
+++ b/src/components/AppRoutes.js
@@ -1,8 +1,9 @@
 import { useEffect } from "react";
-import { useStoreActions } from "easy-peasy";
+import { useStoreState, useStoreActions } from "easy-peasy";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 
 import configData from "../config.json";
+import ThemeSelector from "./ThemeSelector";
 import ScrollToTop from "./ScrollToTop";
 import Timer from "./Timer";
 import Debug from "./Debug";
@@ -22,7 +23,9 @@ import Settings from "./Settings";
 import Footer from "./Footer";
 
 const AppRoutes = () => {
-  const appClasses = "App" + (configData.DEBUG_MODE.ENABLE ? " debug-mode" : "");
+  const appClasses =
+    "App" + (configData.DEBUG_MODE.ENABLE ? " debug-mode" : "");
+  const darkMode = useStoreState((state) => state.darkMode);
   const theApp = configData.INTERACTIVE ? (
     <div className={appClasses}>
       <Timer tick={configData.TIMER.TIMER_TICK_SECS} />
@@ -73,9 +76,18 @@ const AppRoutes = () => {
   }, []);
 
   return (
-    <Router basename={configData.BASE_PATH}>
-      <ScrollToTop>{theApp}</ScrollToTop>
-    </Router>
+    <ThemeSelector
+      isDark={
+        darkMode === "dark" ||
+        (darkMode === "browser" &&
+          window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches)
+      }
+    >
+      <Router basename={configData.BASE_PATH}>
+        <ScrollToTop>{theApp}</ScrollToTop>
+      </Router>
+    </ThemeSelector>
   );
 };
 

--- a/src/components/DarkStyle.js
+++ b/src/components/DarkStyle.js
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import '../darkmode.css';
+
+const DarkStyle = () => <></>;
+
+export default DarkStyle;

--- a/src/components/FilterableProgram.js
+++ b/src/components/FilterableProgram.js
@@ -213,6 +213,8 @@ const FilterableProgram = () => {
                 resetDisplayLimit();
                 setSelLoc(value);
               }}
+              className="filter-container"
+              classNamePrefix="filter-select"
             />
           </div>
           <TagSelectors

--- a/src/components/LightStyle.js
+++ b/src/components/LightStyle.js
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import '../lightmode.css';
+
+const LightStyle = () => <></>;
+
+export default LightStyle;

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -27,6 +27,9 @@ const Settings = () => {
     (actions) => actions.setSelectedTimeZone
   );
 
+  const darkMode = useStoreState((state) => state.darkMode);
+  const setDarkMode = useStoreActions((actions) => actions.setDarkMode);
+
   const timezoneSelect = useTimeZone ? (
     <div>
       <TimeZoneSelect
@@ -41,9 +44,11 @@ const Settings = () => {
 
   return (
     <div className="settings">
-      <h2>{ configData.SETTINGS.TITLE.LABEL }</h2>
+      <h2>{configData.SETTINGS.TITLE.LABEL}</h2>
       <div className="settings-group time-format">
-        <div className="settings-head">{ configData.SETTINGS.TIME_FORMAT.LABEL }</div>
+        <div className="settings-head">
+          {configData.SETTINGS.TIME_FORMAT.LABEL}
+        </div>
         <div className="settings-radio">
           <label>
             <input
@@ -53,7 +58,7 @@ const Settings = () => {
               checked={show12HourTime}
               onChange={(e) => setShow12HourTime(e.target.value === "12hour")}
             />
-            { configData.SETTINGS.TIME_FORMAT.T12_HOUR_LABEL }
+            {configData.SETTINGS.TIME_FORMAT.T12_HOUR_LABEL}
           </label>
           <label>
             <input
@@ -63,12 +68,14 @@ const Settings = () => {
               checked={!show12HourTime}
               onChange={(e) => setShow12HourTime(e.target.value === "12hour")}
             />
-            { configData.SETTINGS.TIME_FORMAT.T24_HOUR_LABEL }
+            {configData.SETTINGS.TIME_FORMAT.T24_HOUR_LABEL}
           </label>
         </div>
       </div>
       <div className="settings-group select-show-localtime">
-        <div className="settings-head">{ configData.SETTINGS.SHOW_LOCAL_TIME.LABEL }</div>
+        <div className="settings-head">
+          {configData.SETTINGS.SHOW_LOCAL_TIME.LABEL}
+        </div>
         <div className="settings-radio">
           <label>
             <input
@@ -78,7 +85,7 @@ const Settings = () => {
               checked={showLocalTime === "never"}
               onChange={(e) => setShowLocalTime(e.target.value)}
             />
-            { configData.SETTINGS.SHOW_LOCAL_TIME.NEVER_LABEL }
+            {configData.SETTINGS.SHOW_LOCAL_TIME.NEVER_LABEL}
           </label>
           <label>
             <input
@@ -88,7 +95,7 @@ const Settings = () => {
               checked={showLocalTime === "differs"}
               onChange={(e) => setShowLocalTime(e.target.value)}
             />
-            { configData.SETTINGS.SHOW_LOCAL_TIME.DIFFERS_LABEL }
+            {configData.SETTINGS.SHOW_LOCAL_TIME.DIFFERS_LABEL}
           </label>
           <label>
             <input
@@ -98,12 +105,14 @@ const Settings = () => {
               checked={showLocalTime === "always"}
               onChange={(e) => setShowLocalTime(e.target.value)}
             />
-            { configData.SETTINGS.SHOW_LOCAL_TIME.ALWAYS_LABEL }
+            {configData.SETTINGS.SHOW_LOCAL_TIME.ALWAYS_LABEL}
           </label>
         </div>
       </div>
       <div className="settings-group select-show-timezone">
-        <div className="settings-head">{ configData.SETTINGS.SHOW_TIMEZONE.LABEL }</div>
+        <div className="settings-head">
+          {configData.SETTINGS.SHOW_TIMEZONE.LABEL}
+        </div>
         <div className="settings-radio">
           <label>
             <input
@@ -113,7 +122,7 @@ const Settings = () => {
               checked={showTimeZone === "never"}
               onChange={(e) => setShowTimeZone(e.target.value)}
             />
-            { configData.SETTINGS.SHOW_TIMEZONE.NEVER_LABEL }
+            {configData.SETTINGS.SHOW_TIMEZONE.NEVER_LABEL}
           </label>
           <label>
             <input
@@ -123,7 +132,7 @@ const Settings = () => {
               checked={showTimeZone === "if_local"}
               onChange={(e) => setShowTimeZone(e.target.value)}
             />
-            { configData.SETTINGS.SHOW_TIMEZONE.IF_LOCAL_LABEL }
+            {configData.SETTINGS.SHOW_TIMEZONE.IF_LOCAL_LABEL}
           </label>
           <label>
             <input
@@ -133,12 +142,14 @@ const Settings = () => {
               checked={showTimeZone === "always"}
               onChange={(e) => setShowTimeZone(e.target.value)}
             />
-            { configData.SETTINGS.SHOW_TIMEZONE.ALWAYS_LABEL }
+            {configData.SETTINGS.SHOW_TIMEZONE.ALWAYS_LABEL}
           </label>
         </div>
       </div>
       <div className="settings-group select-timezone">
-        <div className="settings-head">{ configData.SETTINGS.SELECT_TIMEZONE.LABEL }</div>
+        <div className="settings-head">
+          {configData.SETTINGS.SELECT_TIMEZONE.LABEL}
+        </div>
         <div className="settings-radio">
           <label>
             <input
@@ -148,7 +159,8 @@ const Settings = () => {
               checked={!useTimeZone}
               onChange={(e) => setUseTimeZone(e.target.value === "select")}
             />
-            { configData.SETTINGS.SELECT_TIMEZONE.BROWSER_DEFAULT_LABEL } {defaultTimeZone}
+            {configData.SETTINGS.SELECT_TIMEZONE.BROWSER_DEFAULT_LABEL}{" "}
+            {defaultTimeZone}
           </label>
           <label>
             <input
@@ -158,10 +170,35 @@ const Settings = () => {
               checked={useTimeZone}
               onChange={(e) => setUseTimeZone(e.target.value === "select")}
             />
-            { configData.SETTINGS.SELECT_TIMEZONE.SELECT_LABEL }
+            {configData.SETTINGS.SELECT_TIMEZONE.SELECT_LABEL}
           </label>
         </div>
         {timezoneSelect}
+      </div>
+      <div className="settings-group select-dark-mode">
+        <div className="settings-head">{configData.SETTINGS.DARK_MODE.LABEL}</div>
+        <div className="settings-radio">
+          <label>
+            <input type="radio" value="browser" name="darkmode" checked={darkMode === 'browser'} onChange={(e) => setDarkMode(e.target.value)} />
+            {configData.SETTINGS.DARK_MODE.BROWSER_DEFAULT_LABEL}{" "}
+            {window.matchMedia &&
+            window.matchMedia("(prefers-color-scheme: dark)").matches
+              ? configData.SETTINGS.DARK_MODE.BROWSER_DARK_LABEL
+              : configData.SETTINGS.DARK_MODE.BROWSER_LIGHT_LABEL}
+          </label>
+        </div>
+        <div className="settings-radio">
+          <label>
+            <input type="radio" value="light" name="darkmode" checked={darkMode === 'light'} onChange={(e) => setDarkMode(e.target.value)} />
+            {configData.SETTINGS.DARK_MODE.LIGHT_MODE_LABEL}
+          </label>
+        </div>
+        <div className="settings-radio">
+          <label>
+            <input type="radio" value="dark" name="darkmode" checked={darkMode === 'dark'} onChange={(e) => setDarkMode(e.target.value)} />
+            {configData.SETTINGS.DARK_MODE.DARK_MODE_LABEL}
+          </label>
+        </div>
       </div>
     </div>
   );

--- a/src/components/TagSelect.js
+++ b/src/components/TagSelect.js
@@ -14,7 +14,9 @@ const TagSelect = ({ options, tag, selTags, setSelTags, tagData, resetLimit }) =
         selections[tag] = value;
         setSelTags(selections);
       }}
-    />
+      className="filter-container"
+      classNamePrefix="filter-select"
+/>
   );
 };
 

--- a/src/components/ThemeSelector.js
+++ b/src/components/ThemeSelector.js
@@ -1,0 +1,16 @@
+import React from "react";
+
+const LightStyle = React.lazy(() => import("./LightStyle"));
+const DarkStyle = React.lazy(() => import("./DarkStyle"));
+
+const ThemeSelector = ({ isDark, children }) => (
+  <>
+      <React.Suspense fallback={() => null}>
+         {!isDark && <LightStyle />}
+         {isDark && <DarkStyle />}
+      </React.Suspense>
+      {children}
+  </>
+);
+
+export default ThemeSelector;

--- a/src/config.json
+++ b/src/config.json
@@ -2,8 +2,8 @@
   "BASE_PATH": "/",
   "APP_ID": "O2021",
   "APP_TITLE": "ConClár Programme Guide",
-  "PROGRAM_DATA_URL": "/schedule.jsonp",
-  "PEOPLE_DATA_URL": "/participants.jsonp",
+  "PROGRAM_DATA_URL": "/2022/program.js",
+  "PEOPLE_DATA_URL": "/2022/people.js",
   "FETCH_OPTIONS": {
     "cache": "reload",
     "credentials": "omit",
@@ -11,14 +11,8 @@
       "Origin": "http://example.com"
     }
   },
-  "FETCH_OPTIONS_FIRST": {
-    "credentials": "omit",
-    "headers": {
-      "Origin": "http://example.com"
-    }
-  },
-  "TIMEZONE": "America/Chicago",
-  "TIMEZONECODE": "CDT",
+  "TIMEZONE": "Europe/Dublin",
+  "TIMEZONECODE": "IST",
   "INTERACTIVE": true,
   "HEADER": {
     "IMG_SRC": "",
@@ -79,8 +73,10 @@
     "SEARCHABLE": false,
     "HIDE": false,
     "SEPARATE": [
-      { "PREFIX": "type", "PLACEHOLDER": "Select type", "SEARCHABLE": true, "HIDE": false },
-      { "PREFIX": "test", "PLACEHOLDER": "Select test", "SEARCHABLE": true, "HIDE": false }
+      { "PREFIX": "Division", "PLACEHOLDER": "Select division", "SEARCHABLE": false, "HIDE": true },
+      { "PREFIX": "Type", "PLACEHOLDER": "Select type", "SEARCHABLE": false, "HIDE": false },
+      { "PREFIX": "Tag", "PLACEHOLDER": "Select tag", "SEARCHABLE": false, "HIDE": false },
+      { "PREFIX": "Track", "PLACEHOLDER": "Select track", "SEARCHABLE": false, "HIDE": false }
     ],
     "FORMAT_AS_TAG": false,
     "DAY_TAG": {
@@ -93,7 +89,7 @@
         "1": "Monday"
       },
       "PLACEHOLDER": "Select days",
-      "SEARCHABLE": true,
+      "SEARCHABLE": false,
       "HIDE": false
     }
   },
@@ -217,6 +213,14 @@
       "LABEL": "Select timezone",
       "BROWSER_DEFAULT_LABEL": "Use browser default timezone:",
       "SELECT_LABEL": "Select timezone to use"
+    },
+    "DARK_MODE": {
+      "LABEL": "Dark mode (may require refresh after changing)",
+      "BROWSER_DEFAULT_LABEL": "Use browser default - ",
+      "BROWSER_LIGHT_LABEL": "Light mode",
+      "BROWSER_DARK_LABEL": "Dark mode",
+      "LIGHT_MODE_LABEL": "Always light mode",
+      "DARK_MODE_LABEL": "Always dark mode"
     }
   },
   "FOOTER": {
@@ -225,7 +229,7 @@
   },
   "TIMER": {
     "FETCH_INTERVAL_MINS": 30,
-    "TIMER_TICK_SECS": 300
+    "TIMER_TICK_SECS": 15
   },
   "DEBUG_MODE": {
     "ENABLE": false,

--- a/src/darkmode.css
+++ b/src/darkmode.css
@@ -1,0 +1,37 @@
+/*
+ * Dark mode styles.
+ */
+
+:root {
+  --main-bg: #000;
+  --main-fg: #fff;
+  --navigation-button-bg: #444;
+  --navigation-button-fg: #ddd;
+  --navigation-button-border: #e2e8f0;
+  --navigation-button-current-bg: #5b6473; /*#525e73; #343c4b;*/
+  --navigation-button-current-fg: #fff;
+  --navigation-button-hover-bg: #1e293b;
+  --navigation-button-hover-fg: #fff;
+  --checkbox-switch-bg: #444;
+  --checkbox-selected-bg: green;
+  --checkbox-unselected-bg: red;
+  --filter-bg: var(--main-bg);
+  --filter-fg: var(--main-fg);
+  --filter-border: var(--search-border);
+  --filter-select-bg: #bbe;
+  --filter-select-fg: #000;
+  --search-border: hsl(0, 0%, 40%);
+  --program-item-chevron-collapsed: #ccc;
+  --program-item-chevron-expanded: #bbe;
+  --program-time-convention-message: grey;
+  --program-time-local-message: grey;
+  --program-date-line: #888;
+  --program-time-line: #ccc;
+  --program-item-line: #bbb;
+  --program-tags-fg: #bbb;
+  --program-expanded-bg: #333;
+  --permalink-icon-fg: #265c83;
+  --permalink-icon-hover-fg: #7fdbff;
+  --participant-link-fg: #eee;
+  --participant-link-visited-fg: #ccc;
+}

--- a/src/lightmode.css
+++ b/src/lightmode.css
@@ -1,0 +1,3 @@
+/*
+ * Additional light mode only styles if required.
+ */

--- a/src/model.js
+++ b/src/model.js
@@ -30,6 +30,7 @@ const model = {
   showThumbnails: localStorage.getItem("thumbnails") === "false" ? false : true,
   sortByFullName: localStorage.getItem("sort_people") === "true" ? true : false,
   onLine: window.navigator.onLine,
+  darkMode: localStorage.getItem("dark_mode") ? localStorage.getItem("dark_mode") : 'browser',
   // Thunks
   fetchProgram: thunk(async (actions, firstTime) => {
     actions.setData(await ProgramData.fetchData(firstTime));
@@ -91,6 +92,10 @@ const model = {
   }),
   setOnLine: action((state, onLine) => {
     state.onLine = onLine;
+  }),
+  setDarkMode: action((state, darkMode) => {
+    state.darkMode = darkMode;
+    localStorage.setItem("dark_mode", darkMode);
   }),
 
   // Actions for expanding program items.


### PR DESCRIPTION
This change adds a dark mode option to the settings page of ConClár.
The setting has 3 options:
- Browser default (will use the dark mode preference of the browser).
- Always light mode.
- Always dark mode.
This adds a darkmode.css file, where the dark mode colours can be customised. While any CSS can be overridden here, it is generally expected to be used for overriding colours through CSS variables.
There is also a lightmode.css available if needed, but in almost all cases the light mode should be configured through the main App.css.