### PR TITLE
Allow configuring when links should be enabled

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -63,8 +63,9 @@
   --program-time-bg: #ddd;
   --program-tags-fg: #555;
   --program-expanded-bg: #eee;
-  --permalink-icon-fg: #265c83;
-  --permalink-icon-hover-fg: #193c56;
+  --link-fg: #265c83;
+  --link-hover-fg: #193c56;
+  --link-disabled: #888;
   --participant-bg: #eee;
   --participant-link-fg: #000;
   --participant-link-visited-fg: #444;
@@ -105,12 +106,12 @@ body {
 }
 
 a {
-  color: var(--permalink-icon-fg);
+  color: var(--link-fg);
 
 }
 
 a:hover, a:focus {
-  color: var(--permalink-icon-hover-fg);
+  color: var(--link-hover-fg);
 }
 
 h1,
@@ -670,16 +671,21 @@ input.switch:checked ~ label:after {
 .item-permalink a,
 .item-links a {
   transition: color 0.4s;
-  color: var(--permalink-icon-fg);
+  color: var(--link-fg);
 }
 .item-permalink a:visited,
 .item-links a:visited {
-  color: var(--permalink-icon-fg);
+  color: var(--link-fg);
 }
 .item-permalink a:hover,
 .item-links a:hover {
-  color: var(--permalink-icon-hover-fg);
+  color: var(--link-hover-fg);
 }
+.item-links a:not([href]),
+.item-links a:not([href]):hover {
+  color: var(--link-disabled);
+}
+
 
 /* fix link spacing */
 

--- a/src/ProgramData.js
+++ b/src/ProgramData.js
@@ -65,12 +65,13 @@ export class ProgramData {
     const utcTimeZone = Temporal.TimeZone.from("UTC");
     program.map((item) => {
       const startTime = this.processDateAndTime(item);
-      item.dateAndTime = startTime.withTimeZone(utcTimeZone);
-      item.timeSlot = LocalTime.getTimeSlot(item.dateAndTime);
+      item.startDateAndTime = startTime.withTimeZone(utcTimeZone);
+      item.endDateAndTime = item.startDateAndTime.add({ minutes: item.mins ? item.mins : 0});
+      item.timeSlot = LocalTime.getTimeSlot(item.startDateAndTime);
       return item;
     });
     program.sort((a, b) => {
-      return Temporal.ZonedDateTime.compare(a.dateAndTime, b.dateAndTime);
+      return Temporal.ZonedDateTime.compare(a.startDateAndTime, b.startDateAndTime);
     });
     //console.log("Program data", program);
     return program;
@@ -314,14 +315,14 @@ export class ProgramData {
       for (const item of taggedItems) {
         // Get the day of the program (this shouldn't apply for participants) item.
         const dayValue = LocalTime.formatISODateInConventionTimeZone(
-          item.dateAndTime
+          item.startDateAndTime
         );
         const dayTag = tags.days.includes(dayValue)
           ? tags.days[dayValue]
           : addTag(tags.days, {
               value: dayValue,
               label: LocalTime.formatDayNameInConventionTimeZone(
-                item.dateAndTime
+                item.startDateAndTime
               ),
               category: "days",
             });

--- a/src/components/Day.js
+++ b/src/components/Day.js
@@ -1,8 +1,9 @@
 import PropTypes from "prop-types";
 import TimeSlot from "./TimeSlot";
 import { LocalTime } from "../utils/LocalTime";
+import { Temporal } from "@js-temporal/polyfill";
 
-const Day = ({ date, items, forceExpanded }) => {
+const Day = ({ date, items, forceExpanded, now }) => {
   const day = LocalTime.formatDateForLocaleAsUTC(date);
   const rows = [];
   let itemRows = [];
@@ -18,12 +19,13 @@ const Day = ({ date, items, forceExpanded }) => {
             dateAndTime={curDateAndTime}
             items={itemRows}
             forceExpanded={forceExpanded}
+            now={now}
           />
         );
         itemRows = [];
       }
       curTimeSlot = item.timeSlot;
-      curDateAndTime = item.dateAndTime;
+      curDateAndTime = item.startDateAndTime;
     }
     itemRows.push(item);
   });
@@ -34,6 +36,7 @@ const Day = ({ date, items, forceExpanded }) => {
       dateAndTime={curDateAndTime}
       items={itemRows}
       forceExpanded={forceExpanded}
+      now={now}
     />
   );
 
@@ -52,6 +55,7 @@ Day.defaultProps = {
 Day.propTypes = {
   items: PropTypes.array,
   forceExpanded: PropTypes.bool,
+  now: PropTypes.instanceOf(Temporal.ZonedDateTime),
 };
 
 export default Day;

--- a/src/components/ItemLink.js
+++ b/src/components/ItemLink.js
@@ -1,7 +1,7 @@
 
-const ItemLink = ({ name, link, text }) => {
+const ItemLink = ({ name, link, text, enabled }) => {
   return <div className={name}>
-    <a href={link}>{text}</a>
+    <a className={enabled ? null : "disabled"} href={enabled ? link : null}>{text}</a>
   </div>;
 };
 

--- a/src/components/ProgramItem.js
+++ b/src/components/ProgramItem.js
@@ -11,8 +11,9 @@ import Tag from "./Tag";
 import Participant from "./Participant";
 import configData from "../config.json";
 import PropTypes from "prop-types";
+import { Temporal } from "@js-temporal/polyfill";
 
-const ProgramItem = ({ item, forceExpanded }) => {
+const ProgramItem = ({ item, forceExpanded, now }) => {
   const selected = useStoreState((state) => state.isSelected(item.id));
   const { addSelection, removeSelection } = useStoreActions((actions) => ({
     addSelection: actions.addSelection,
@@ -37,6 +38,16 @@ const ProgramItem = ({ item, forceExpanded }) => {
   function handleSelected(event) {
     if (event.target.checked) addSelection(item.id);
     else removeSelection(item.id);
+  }
+
+  function getRelativeTime(item) {
+    if (Temporal.ZonedDateTime.compare(now, item.startDateAndTime) < 0) {
+      return "before";
+    } else if (Temporal.ZonedDateTime.compare(now, item.endDateAndTime) < 0) {
+      return "during";
+    } else {
+      return "after";
+    }
   }
 
   let id = "item_" + item.id;
@@ -89,12 +100,14 @@ const ProgramItem = ({ item, forceExpanded }) => {
   if (configData.LINKS) {
     configData.LINKS.forEach((link) => {
       if (item.links && item.links[link.NAME] && item.links[link.NAME].length) {
+        const enabled = !link.WHEN || link.WHEN.indexOf(getRelativeTime(item)) >= 0;
         links.push(
           <ItemLink
             key={link.NAME}
             name={"item-links-" + link.NAME}
             link={item.links[link.NAME]}
             text={link.TEXT}
+            enabled={enabled}
           />
         );
       }
@@ -181,6 +194,7 @@ ProgramItem.defaultProps = {
 
 ProgramItem.propTypes = {
   forceExpanded: PropTypes.bool,
+  now: PropTypes.instanceOf(Temporal.ZonedDateTime),
 };
 
 export default ProgramItem;

--- a/src/components/ProgramList.js
+++ b/src/components/ProgramList.js
@@ -1,16 +1,23 @@
-import React, { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import PropTypes from "prop-types";
 import { useStoreState } from "easy-peasy";
 import { LocalTime } from "../utils/LocalTime";
 import Day from "./Day";
 import configData from "../config.json";
-// import { Temporal } from "@js-temporal/polyfill";
+import { Temporal } from "@js-temporal/polyfill";
 
 const ProgramList = ({ program, forceExpanded }) => {
   const showLocalTime = useStoreState((state) => state.showLocalTime);
   useEffect(() => {
     LocalTime.storeCachedTimes();
   });
+
+  const [now, setNow] = useState(Temporal.Now.zonedDateTimeISO("UTC"));
+  useEffect(() => {
+    setInterval(() => {
+      setNow(Temporal.Now.zonedDateTimeISO("UTC"));
+    }, 10000);
+  }, []);
 
   LocalTime.checkTimeZonesDiffer(program);
 
@@ -27,7 +34,7 @@ const ProgramList = ({ program, forceExpanded }) => {
   }
 
   program.forEach((item) => {
-    const itemDate = item.dateAndTime
+    const itemDate = item.startDateAndTime
       .withTimeZone(LocalTime.conventionTimeZone)
       .round({ smallestUnit: "day", roundingMode: "floor" });
 
@@ -39,6 +46,7 @@ const ProgramList = ({ program, forceExpanded }) => {
             date={curDate}
             items={itemRows}
             forceExpanded={forceExpanded}
+            now={now}
           />
         );
         itemRows = [];
@@ -53,6 +61,7 @@ const ProgramList = ({ program, forceExpanded }) => {
       date={curDate}
       items={itemRows}
       forceExpanded={forceExpanded}
+      now={now}
     />
   );
   const conventionTime = (

--- a/src/components/TimeSlot.js
+++ b/src/components/TimeSlot.js
@@ -2,8 +2,9 @@ import PropTypes from "prop-types";
 import { useStoreState } from "easy-peasy";
 import ProgramItem from "./ProgramItem";
 import { LocalTime } from "../utils/LocalTime";
+import { Temporal } from "@js-temporal/polyfill";
 
-const TimeSlot = ({ timeSlot, dateAndTime, items, forceExpanded }) => {
+const TimeSlot = ({ timeSlot, dateAndTime, items, forceExpanded, now }) => {
   const showLocalTime = useStoreState((state) => state.showLocalTime);
   const show12HourTime = useStoreState((state) => state.show12HourTime);
   const timeZoneIsShown = useStoreState((state) => state.timeZoneIsShown);
@@ -37,7 +38,7 @@ const TimeSlot = ({ timeSlot, dateAndTime, items, forceExpanded }) => {
   const rows = [];
   items.forEach((item) => {
     rows.push(
-      <ProgramItem key={item.id} item={item} forceExpanded={forceExpanded} />
+      <ProgramItem key={item.id} item={item} forceExpanded={forceExpanded} now={now} />
     );
   });
 
@@ -61,6 +62,7 @@ TimeSlot.defaultProps = {
 TimeSlot.propTypes = {
   items: PropTypes.array,
   forceExpanded: PropTypes.bool,
+  now: PropTypes.instanceOf(Temporal.ZonedDateTime),
 };
 
 export default TimeSlot;

--- a/src/config_example.json
+++ b/src/config_example.json
@@ -126,11 +126,13 @@
     },
     {"NAME": "meeting",
      "TEXT": "Click to view stream",
-     "TAG": "type:Streaming"
+     "TAG": "type:Streaming",
+     "WHEN": ["during"]
     },
     {"NAME": "recording",
      "TEXT": "Click to view recording",
-     "TAG": ""
+     "TAG": "",
+     "WHEN": ["after"]
     }
   ],
   "CONVENTION_TIME": {

--- a/src/utils/LocalTime.js
+++ b/src/utils/LocalTime.js
@@ -225,12 +225,12 @@ export class LocalTime {
       this.timezonesDiffer = false;
       return false;
     }
-    if (this.checkTimeZoneOffsetForDate(program[0].dateAndTime)) {
+    if (this.checkTimeZoneOffsetForDate(program[0].startDateAndTime)) {
       this.timezonesDiffer = true;
       return true;
     }
     const [lastItem] = program.slice(-1);
-    if (this.checkTimeZoneOffsetForDate(lastItem.dateAndTime)) {
+    if (this.checkTimeZoneOffsetForDate(lastItem.startDateAndTime)) {
       this.timezonesDiffer = true;
       return true;
     }
@@ -413,14 +413,14 @@ export class LocalTime {
         minutes: configData.SHOW_PAST_ITEMS.ADJUST_MINUTES,
       });
       return program.filter((item) => {
-        return Temporal.ZonedDateTime.compare(cutOff, item.dateAndTime) <= 0;
+        return Temporal.ZonedDateTime.compare(cutOff, item.startDateAndTime) <= 0;
       });
     } else {
       const cutOff = Temporal.Now.zonedDateTimeISO("UTC").subtract({
         minutes: configData.SHOW_PAST_ITEMS.ADJUST_MINUTES,
       });
       return program.filter((item) => {
-        const itemNearEndTime = item.dateAndTime.add({
+        const itemNearEndTime = item.startDateAndTime.add({
           minutes: item.hasOwnProperty("mins")
             ? item.mins
             : configData.SHOW_PAST_ITEMS.ADJUST_MINUTES,
@@ -442,11 +442,9 @@ export class LocalTime {
       return false;
     }
     const now = Temporal.Now.zonedDateTimeISO("UTC");
-    const startTime = program[0].dateAndTime;
+    const startTime = program[0].startDateAndTime;
     const [lastItem] = program.slice(-1);
-    const endTime = lastItem.dateAndTime.add({
-      minutes: lastItem.mins ? lastItem.mins : 0,
-    });
+    const endTime = lastItem.endDateAndTime;
     // True if between start of first item and end of last item.
     // ToDo: consider edge case where the item with the latest end time is not the last item.
     return (


### PR DESCRIPTION
Links can now be configured with whether they should be enabled before, during or after the item.

Sometimes streaming links aren't a link to the specific item, but to a stream for the room the item is in. People can get confused if the click on a "Click to view stream" link for an item that isn't currently on and see a different item. To avoid this confusion, we can now configure the streaming links to only be enabled during the item.

Similarly, replays aren't typically available until after the item has finished.

If no `WHEN` is configured, it is assumed to be always enabled.