### PR TITLE
Push footer to bottom of screen

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -98,6 +98,9 @@ body {
 }
 
 .App {
+  display: grid;
+  height: 100dvh;
+  grid-template-rows: auto 1fr auto;
   text-align: left;
   margin: 1rem;
   font-size: 1.25rem;

--- a/src/components/AppRoutes.js
+++ b/src/components/AppRoutes.js
@@ -8,7 +8,6 @@ import ScrollToTop from "./ScrollToTop";
 import Timer from "./Timer";
 import Debug from "./Debug";
 import Header from "./Header";
-import Navigation from "./Navigation";
 import NotFound from "./NotFound";
 import Loading from "./Loading";
 import FilterableProgram from "./FilterableProgram";
@@ -30,8 +29,7 @@ const AppRoutes = () => {
     <div className={appClasses}>
       <Timer tick={configData.TIMER.TIMER_TICK_SECS} />
       <Debug />
-      <Header title={configData.APP_TITLE} />
-      <Navigation />
+      <Header title={configData.APP_TITLE} showNavigation={true} />
       <Loading>
         <Routes>
           <Route path="/">
@@ -54,7 +52,7 @@ const AppRoutes = () => {
     </div>
   ) : (
     <div className="App">
-      <Header title={configData.APP_TITLE} />
+      <Header title={configData.APP_TITLE} showNavigation={false} />
       <Loading>
         <Routes>
           <Route path="/">

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,16 +1,18 @@
 import PropTypes from "prop-types";
 import configData from "../config.json";
+import Navigation from "./Navigation";
 
 const headerImg = configData.HEADER.IMG_SRC ? <img src={configData.HEADER.IMG_SRC} alt={configData.HEADER.IMG_ALT_TEXT}></img> : "";
 const showBreak = configData.HEADER.LINEFEED_AFTER_URL ? <br /> : "";
 
-const Header = ({ title }) => {
+const Header = ({ title, showNavigation = true }) => {
   document.title = title;
   return (
     <header>
       {headerImg}
       {showBreak}
       <h1>{title}</h1>
+      { showNavigation ? <Navigation /> : <></> }
     </header>
   );
 };


### PR DESCRIPTION
Currently the footer will hover in the middle of the page if the page doesn't fill the screen.

This change will formats the App as a CSS grid, set to fill the display viewport.

The header and footer rows are set to "auto" height, so will take minimum required space. The content row is set to `1fr` (fractional unit), which will cause it to expand to fill available space.

If the page is taller than the screen, it will scroll normally.

As part of this, I've moved the navigation into the header.