### PR TITLE
Add dropdown with times to hide items before

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ The main place customisations go is the `src/config.json` file. Settings current
 - `TAGS.DAY_TAG.SEARCHABLE`: Whether day tag list can be searched by typing.
 - `TAGS.DAY_TAG.HIDE`: If true, hide day tags drop-down. Day tags still shown on items if GENERATE true.
 - `TAGS.DONTLIST`: An array of tags not to list in the drop-downs and programme item tag lists.
+- `HIDE_BEFORE.HIDE`: If true hide "hide before" dropdown. If false, show dropdown containing times to hide items before.
+- `HIDE_BEFORE.PLACEHOLDER`: Placeholder text for hide before drop-down.
+- `HIDE_BEFORE.TIMES`: Array of times to list in hide before drop-down. Each entry should be specified as follows: { "TIME": "time in hh:mm:ss format", "LABEL_24H": "24 hour label", "LABEL_12H": "12 hour label" }. Time should be in convention timezone.
 - `FILTER.RESET.LABEL`: The label for the "Reset filters" button.
 - `PERMALINK.SHOW_PERMALINK`: If true, display a "permalink" icon when each program item is expanded.
 - `PERMALINK.PERMALINK_TITLE`: "Title" text displayed when mouse is hovered over permalink icon.

--- a/src/App.css
+++ b/src/App.css
@@ -365,6 +365,22 @@ input.switch:checked ~ label:after {
   max-width: 50ch;
 }
 
+.filter-hide-before {
+  max-width: 30ch;
+  margin: auto 0.25em;
+}
+
+.filter-hide-before label {
+  display: none;
+}
+
+.filter-hide-before select
+{
+  font-size: 1rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
 .filter-search label {
   display: none;
 }

--- a/src/config_example.json
+++ b/src/config_example.json
@@ -100,6 +100,18 @@
     },
     "DONTLIST": ["Division", "days"]
   },
+  "HIDE_BEFORE": {
+    "HIDE": false,
+    "PLACEHOLDER": "Hide before",
+    "TIMES": [
+      { "TIME": "10:00:00", "LABEL_24H": "10:00", "LABEL_12H": "10am" },
+      { "TIME": "12:00:00", "LABEL_24H": "12:00", "LABEL_12H": "12 noon" },
+      { "TIME": "14:00:00", "LABEL_24H": "14:00", "LABEL_12H": "2pm" },
+      { "TIME": "16:00:00", "LABEL_24H": "16:00", "LABEL_12H": "4pm" },
+      { "TIME": "18:00:00", "LABEL_24H": "18:00", "LABEL_12H": "6pm" },
+      { "TIME": "20:00:00", "LABEL_24H": "20:00", "LABEL_12H": "8pm" }
+    ]
+  },
   "FILTER": {
     "RESET": {
       "LABEL": "Reset filters"

--- a/src/model.js
+++ b/src/model.js
@@ -24,6 +24,7 @@ const model = {
   mySelections: ProgramSelection.getAllSelections(),
   programSelectedLocations: [],
   programSelectedTags: {},
+  programHideBefore: "",
   programSearch: "",
   peopleSelectedTags: {},
   peopleSearch: "",
@@ -138,6 +139,9 @@ const model = {
   setProgramSelectedTags: action((state, selectedTags) => {
     state.programSelectedTags = selectedTags;
   }),
+  setProgramHideBefore: action((state, hideBefore) => {
+    state.programHideBefore = hideBefore;
+  }),
   setProgramSearch: action((state, search) => {
     state.programSearch = search;
   }),
@@ -148,6 +152,7 @@ const model = {
       newTags[tag] = [];
     }
     state.programSelectedTags = newTags;
+    state.programHideBefore = "";
     state.programSearch = "";
   }),
   setPeopleSelectedTags: action((state, selectedTags) => {
@@ -196,6 +201,7 @@ const model = {
     if (state.programSelectedLocations.length > 0) return true;
     for (const tag in state.programSelectedTags)
       if (state.programSelectedTags[tag].length > 0) return true;
+    if (state.programHideBefore.length > 0) return true;
     if (state.programSearch.length > 0) return true;
     return false;
   }),


### PR DESCRIPTION
Adds a new filter drop-down with a lit of times. Items before selected time on first day in filter will be hidden.

This is to improve accessibility and reduce the number of items screen reader users have to go through.