### PR TITLE
Make alt text on participant image in program item blank

### DIFF
--- a/src/components/Participant.js
+++ b/src/components/Participant.js
@@ -10,7 +10,7 @@ const Participant = ({ person, thumbnails, moderator }) => {
           <div className="participant-image">
             <img
               src={person.img}
-              alt={person.name}
+              alt=""
               onError={({ currentTarget }) => {
                 currentTarget.onerror = null;
                 currentTarget.style.display = "none";
@@ -30,7 +30,7 @@ const Participant = ({ person, thumbnails, moderator }) => {
                 configData.BASE_PATH +
                 configData.PEOPLE.THUMBNAILS.DEFAULT_IMAGE
               }
-              alt={person.name}
+              alt=""
             />
           </div>
         );


### PR DESCRIPTION
Testing with Wave reports images with alt text the same as nearby text. Making alt text blank for participant image in programme item to correct.