### PR TITLE
Hide Information navigation link if not present in configuration.

### DIFF
--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -2,6 +2,14 @@ import { NavLink } from "react-router-dom";
 import configData from "../config.json";
 
 const Navigation = () => {
+  const infoLink =
+    "INFO" in configData.NAVIGATION ? (
+      <li>
+        <NavLink to="/info">{configData.NAVIGATION.INFO}</NavLink>
+      </li>
+    ) : (
+      <></>
+    );
   const extraLinks = [];
   if ("EXTRA" in configData.NAVIGATION) {
     for (let link of configData.NAVIGATION.EXTRA) {
@@ -24,9 +32,7 @@ const Navigation = () => {
         <li>
           <NavLink to="/myschedule">{configData.NAVIGATION.MYSCHEDULE}</NavLink>
         </li>
-        <li>
-          <NavLink to="/info">{configData.NAVIGATION.INFO}</NavLink>
-        </li>
+        {infoLink}
         <li>
           <NavLink to="/settings">{configData.NAVIGATION.SETTINGS}</NavLink>
         </li>


### PR DESCRIPTION
Previously if Information link was not present, and empty button would be displayed. However, some conventions may have an information page elsewhere, so may not want this in the programme guide. This change will not show the button if the NAVIGATION.INFO config item is not present.