### PR TITLE
Create more compressed QR codes 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.1.0",
       "dependencies": {
         "@js-temporal/polyfill": "^0.4.0",
+        "@scure/base": "^1.1.7",
         "@testing-library/jest-dom": "^5.16.1",
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
         "dompurify": "^2.3.4",
         "easy-peasy": "^5.0.4",
+        "pako": "^2.1.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-icons": "^4.3.1",
@@ -4647,6 +4649,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.4.tgz",
       "integrity": "sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA=="
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.7.tgz",
+      "integrity": "sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@sideway/address": {
       "version": "4.1.4",
@@ -16764,6 +16774,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -26748,6 +26763,11 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.4.tgz",
       "integrity": "sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA=="
     },
+    "@scure/base": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.7.tgz",
+      "integrity": "sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g=="
+    },
     "@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -35890,6 +35910,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
+    "pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "param-case": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-icons": "^4.3.1",
         "react-infinite-scroll-component": "^6.1.0",
         "react-markdown": "^7.1.2",
-        "react-qr-code": "^2.0.7",
+        "react-qrcode-pretty": "^1.3.2",
         "react-router-dom": "^6.2.1",
         "react-scripts": "^5.0.1",
         "react-select": "^5.2.2",
@@ -18397,10 +18397,10 @@
         "teleport": ">=0.2.0"
       }
     },
-    "node_modules/qr.js": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
-      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
+    "node_modules/qrcode-generator": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-1.4.4.tgz",
+      "integrity": "sha512-HM7yY8O2ilqhmULxGMpcHSF1EhJJ9yBj8gvDEuZ6M+KGJ0YY2hKpnXvRD+hZPLrDVck3ExIGhmPtSdcjC+guuw=="
     },
     "node_modules/qs": {
       "version": "6.10.3",
@@ -18677,22 +18677,16 @@
       "integrity": "sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g==",
       "peer": true
     },
-    "node_modules/react-qr-code": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.7.tgz",
-      "integrity": "sha512-NpknL80p7dWbLdHfBSIxQIqLCu3+kBlyzYD692rO0UnVwfCSziIxc1xn/p3JhPEv1RV1lRD8j0w+hR3L7tawTQ==",
+    "node_modules/react-qrcode-pretty": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/react-qrcode-pretty/-/react-qrcode-pretty-1.3.2.tgz",
+      "integrity": "sha512-yaEeNhpNwZk+UJGAj2BqRhpe24Nu4pgTJh2WocNtip6+HYND8CDZXJmfRG1XADD7OCM18AfCeuSj+LyyyF1I/Q==",
       "dependencies": {
-        "prop-types": "^15.7.2",
-        "qr.js": "0.0.0"
+        "qrcode-generator": "^1.4.4"
       },
       "peerDependencies": {
-        "react": "^16.x || ^17.x || ^18.x",
-        "react-native-svg": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-svg": {
-          "optional": true
-        }
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-refresh": {
@@ -36911,10 +36905,10 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
     },
-    "qr.js": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
-      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
+    "qrcode-generator": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-1.4.4.tgz",
+      "integrity": "sha512-HM7yY8O2ilqhmULxGMpcHSF1EhJJ9yBj8gvDEuZ6M+KGJ0YY2hKpnXvRD+hZPLrDVck3ExIGhmPtSdcjC+guuw=="
     },
     "qs": {
       "version": "6.10.3",
@@ -37129,13 +37123,12 @@
       "integrity": "sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g==",
       "peer": true
     },
-    "react-qr-code": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/react-qr-code/-/react-qr-code-2.0.7.tgz",
-      "integrity": "sha512-NpknL80p7dWbLdHfBSIxQIqLCu3+kBlyzYD692rO0UnVwfCSziIxc1xn/p3JhPEv1RV1lRD8j0w+hR3L7tawTQ==",
+    "react-qrcode-pretty": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/react-qrcode-pretty/-/react-qrcode-pretty-1.3.2.tgz",
+      "integrity": "sha512-yaEeNhpNwZk+UJGAj2BqRhpe24Nu4pgTJh2WocNtip6+HYND8CDZXJmfRG1XADD7OCM18AfCeuSj+LyyyF1I/Q==",
       "requires": {
-        "prop-types": "^15.7.2",
-        "qr.js": "0.0.0"
+        "qrcode-generator": "^1.4.4"
       }
     },
     "react-refresh": {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "private": true,
   "dependencies": {
     "@js-temporal/polyfill": "^0.4.0",
+    "@scure/base": "^1.1.7",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
     "dompurify": "^2.3.4",
     "easy-peasy": "^5.0.4",
+    "pako": "^2.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react-icons": "^4.3.1",
     "react-infinite-scroll-component": "^6.1.0",
     "react-markdown": "^7.1.2",
-    "react-qr-code": "^2.0.7",
+    "react-qrcode-pretty": "^1.3.2",
     "react-router-dom": "^6.2.1",
     "react-scripts": "^5.0.1",
     "react-select": "^5.2.2",

--- a/src/components/AppRoutes.js
+++ b/src/components/AppRoutes.js
@@ -15,6 +15,7 @@ import UnfilterableProgram from "./UnfilterableProgram";
 import MySchedule from "./MySchedule";
 import ItemById from "./ItemById";
 import ItemByIdList from "./ItemByIdList";
+import GzItemByIdList from "./GzItemByIdList";
 import People from "./People";
 import Person from "./Person";
 import Info from "./Info";
@@ -37,6 +38,7 @@ const AppRoutes = () => {
             <Route path="/index.html" element={<FilterableProgram />} />
             <Route path="id/:id" element={<ItemById />} />
             <Route path="ids/:idList" element={<ItemByIdList />} />
+            <Route path="GZIDS/:idList" element={<GzItemByIdList />} />
             <Route path="people">
               <Route index element={<People />} />
               <Route path=":id" element={<Person />} />

--- a/src/components/GzItemByIdList.js
+++ b/src/components/GzItemByIdList.js
@@ -11,7 +11,7 @@ const ItemByIdList = () => {
   })); 
 
   const params = useParams();
-  const gzids = base32.decode(params.idList);
+  const gzids = base32.decode(params.idList.replaceAll("-","="));
   const rawList = inflate(gzids, {to: 'string'});
   console.log(rawList);
   const itemIds = rawList.split("~");

--- a/src/components/GzItemByIdList.js
+++ b/src/components/GzItemByIdList.js
@@ -1,0 +1,48 @@
+import { useStoreState, useStoreActions } from "easy-peasy";
+import { useParams } from "react-router-dom";
+import { base32 } from "@scure/base";
+import { inflate } from "pako";
+import configData from "../config.json";
+import ProgramList from "./ProgramList";
+
+const ItemByIdList = () => {
+  const { addSelection } = useStoreActions((actions) => ({
+    addSelection: actions.addSelection,
+  })); 
+
+  const params = useParams();
+  const gzids = base32.decode(params.idList);
+  const rawList = inflate(gzids, {to: 'string'});
+  console.log(rawList);
+  const itemIds = rawList.split("~");
+  const program = useStoreState((state) => state.program);
+  if (program.length === 0) return <></>;
+
+  // Filter to select only the specified ID.
+  const filteredProgram = program.filter((item) =>
+    itemIds.includes(item.id.toString())
+  );
+  return (
+    <div>
+      <div className="page-heading">
+        <h2>{configData.PROGRAM.SHARED.TITLE}</h2>
+      </div>
+      <div className="page-body">{configData.PROGRAM.SHARED.DESCRIPTION}</div>
+      <ProgramList program={filteredProgram} />
+      <div className="buttons">
+        <button
+          className="button-add-all"
+          onClick={() => {
+            itemIds.forEach((id) => {
+              addSelection(id);
+            });
+          }}
+        >
+          {configData.PROGRAM.SHARED.BUTTON_LABEL}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ItemByIdList;

--- a/src/components/ShareLink.js
+++ b/src/components/ShareLink.js
@@ -46,6 +46,7 @@ const ShareLink = () => {
         <div className="share-qr-code">
           <QrCode
                 value={absLink}
+                resize="265px"
                 mode={qrmode}
            />
         </div>

--- a/src/components/ShareLink.js
+++ b/src/components/ShareLink.js
@@ -1,5 +1,7 @@
 import { useStoreState } from "easy-peasy";
 import { Link } from "react-router-dom";
+import { deflate } from "pako";
+import { base32 } from '@scure/base';
 import QRCode from "react-qr-code";
 import configData from "../config.json";
 
@@ -9,9 +11,22 @@ const ShareLink = () => {
   if (mySchedule.length === 0) return <></>;
   const links = [];
   let key = 0;
+
+  function makeLink(linkItems, compress) {
+    if (!compress) {
+        return  "IDS/" + linkItems;
+    } else {
+        // const deflator= new Deflate();
+        // deflator.push(linkItems,true)
+        const param=base32.encode(deflate(linkItems));
+        return configData.BASE_PATH.toUpperCase() + "GZIDS/" + param;
+    }
+  }
+
   function addLink(linkItems, multi) {
-    const link = configData.BASE_PATH + "ids/" + linkItems;
-    const absLink = `${window.location.origin}${link}`;
+    const link = makeLink(linkItems,true);
+    const hostOrigin = String(window.location.origin).toUpperCase();
+    const absLink = `${hostOrigin}${link}`;
     links.push(
       <div key={key++} className="share-body">
         <div className="share-link">

--- a/src/components/ShareLink.js
+++ b/src/components/ShareLink.js
@@ -14,7 +14,7 @@ const ShareLink = () => {
 
   function makeLink(linkItems, compress) {
     if (!compress) {
-        return  "IDS/" + linkItems;
+        return  "ids/" + linkItems;
     } else {
         // const deflator= new Deflate();
         // deflator.push(linkItems,true)
@@ -24,8 +24,11 @@ const ShareLink = () => {
   }
 
   function addLink(linkItems, multi) {
-    const link = makeLink(linkItems,true);
-    const hostOrigin = String(window.location.origin).toUpperCase();
+    const compress = configData.PROGRAM.MY_SCHEDULE.SHARE.COMPRESS;
+    const link = makeLink(linkItems,compress);
+    console.log("Link=", link);
+    const hostOrigin = compress ? String(window.location.origin).toUpperCase() :
+                                  window.location.origin;
     const absLink = `${hostOrigin}${link}`;
     links.push(
       <div key={key++} className="share-body">

--- a/src/components/ShareLink.js
+++ b/src/components/ShareLink.js
@@ -2,7 +2,7 @@ import { useStoreState } from "easy-peasy";
 import { Link } from "react-router-dom";
 import { deflate } from "pako";
 import { base32 } from '@scure/base';
-import QRCode from "react-qr-code";
+import { QrCode } from "react-qrcode-pretty";
 import configData from "../config.json";
 
 const ShareLink = () => {
@@ -26,10 +26,11 @@ const ShareLink = () => {
   function addLink(linkItems, multi) {
     const compress = configData.PROGRAM.MY_SCHEDULE.SHARE.COMPRESS;
     const link = makeLink(linkItems,compress);
-    console.log("Link=", link);
     const hostOrigin = compress ? String(window.location.origin).toUpperCase() :
                                   window.location.origin;
+ 
     const absLink = `${hostOrigin}${link}`;
+    const qrmode = compress ? "Alphanumeric" :"Byte";
     links.push(
       <div key={key++} className="share-body">
         <div className="share-link">
@@ -43,7 +44,10 @@ const ShareLink = () => {
           </Link>
         </div>
         <div className="share-qr-code">
-          <QRCode value={absLink} />
+          <QrCode
+                value={absLink}
+                mode={qrmode}
+           />
         </div>
       </div>
     );

--- a/src/components/ShareLink.js
+++ b/src/components/ShareLink.js
@@ -18,7 +18,7 @@ const ShareLink = () => {
     } else {
         // const deflator= new Deflate();
         // deflator.push(linkItems,true)
-        const param=base32.encode(deflate(linkItems));
+        const param=base32.encode(deflate(linkItems)).replaceAll("=","-");
         return configData.BASE_PATH.toUpperCase() + "GZIDS/" + param;
     }
   }

--- a/src/config_example.json
+++ b/src/config_example.json
@@ -64,6 +64,7 @@
         "DESCRIPTION": "Copy and paste this link to share your selections with other devices. Or point your camera at the QR code below.",
         "LINK_LABEL": "Shareable link",
         "MAX_LENGTH": 2500,
+        "COMPRESS": false,
         "MULTIPLE_DESCRIPTION": "Because you have selected a large number of items, you will need to use multiple links/QR codes to transfer to your other devices.",
         "MULTIPLE_LINK_LABEL": "Shareable link #@number"
       }


### PR DESCRIPTION
This set of patches tries to produce a more optimally reduced URL/ QR Code representation for the MySchedule links.

**Principle of Operation:**

We first use deflate to reduce bitstream to a minimum. Unfortunately that gets us a binary bitstream which can't be encoded into a URL, so we need to use an expanding encoding to fit the data into the URL-safe characters.
We chose to use a Base32 scheme for this which will fit it into the QR codes 'Alphanumeric' encoding alphabet, as a result of this,  5 bits in the deflate stream should take 5.5 bits on the QR code bitstream.

The downside of this is that I couldn't find a react qr component which supports using different encoding schemes for different segments of the QR code data (allowed by the QR standard). Additionally the Qr component currently used by conclar only supports the full eight-bit encoding scheme, so I have swapped the whole component for react-qr-pretty 
at the cost of a different size of presentation of the QR code on the page.

As a result, the whole URL has to be rendered as upper case, it wouldn't be impossible to add the multi-segment feature to a react QR component but I felt it was out of scope for this PR.

The URL generated also uses a different subpath from the non-compressed one so that even if compression on codes is switched off both forms of URLs can be accepted, allowing conventions using thissoftware to switch modes without invalidating 'released' QR codes.

**Coding Choices.**

I've tried to keep the changes to conclar as small as possible to implement this feature. Instead of making intrusive changes to ItemByIdList.js, I've copied it and added the changes to GzItemByList.js It should be possible to combine them if that was considered a good idea.
