### PR TITLE
Add map links to rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ The main place customisations go is the `src/config.json` file. Settings current
 - `HELP_TEXT.CLOSE_LABEL`: Label for button to dismiss help text.
 - `HELP_TEXT.CLOSE_ARIA_LABEL`: Label to describe dismiss button.
 - `LOCATIONS.SEARCHABLE`: Whether the location list can be searched by typing. (Searching can be inconvenient on touch screens.)
+- `LOCATIONS.LABEL`: Label to show on map links.
+- `LOCATIONS.MAPPING`: Array of locations, with links to show on map. Each room should be specified as: `{ "KEY": "Room name", "MAP_URL": "link to map" }`.
 - `APPLICATION.LOADING.MESSAGE`: Message to display while loading.
 - `PROGRAM.LIMIT.SHOW`: If true, "limit number of items" drop-down will be displayed.
 - `PROGRAM.LIMIT.LABEL`: Label for limit drop-down.

--- a/src/components/ProgramItem.js
+++ b/src/components/ProgramItem.js
@@ -114,6 +114,22 @@ const ProgramItem = ({ item, forceExpanded, now }) => {
     });
   }
 
+  if ('MAPPING' in configData.LOCATIONS) {
+    for (const location of configData.LOCATIONS.MAPPING) {
+      if (item.loc.toString() === location.KEY) {
+        links.push(
+          <ItemLink
+            key="map"
+            name="item-links-map"
+            link={location.MAP_URL}
+            text={configData.LOCATIONS.LABEL}
+            enabled={true}
+          />
+        )
+      }
+    }
+  }
+
   const duration =
     configData.DURATION.SHOW_DURATION && item.mins ? (
       <div className="item-duration">

--- a/src/config_example.json
+++ b/src/config_example.json
@@ -40,7 +40,11 @@
     "CLOSE_ARIA_LABEL": "Dismiss help text"
   },
   "LOCATIONS": {
-    "SEARCHABLE": false
+    "SEARCHABLE": false,
+    "LABEL": "Show on map",
+    "MAPPING": [
+      { "KEY": "Davin - Croke Park", "MAP_URL": "https://map.octocon.com" }
+    ]
   },
   "APPLICATION": {
     "LOADING": {


### PR DESCRIPTION
This change allows a map link to be configured for each room. All programme items where the `loc`  matches the room name in the mapping table will add the room's link to the links table.

This goes some way towards fixing #169. However, there could be a case for follow up issues to make it more generic.