### PR TITLE
Use CSS to remove extraneous comma from end of tag list

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -715,6 +715,14 @@ input.switch:checked ~ label:after {
   margin-right: 0.5rem;
 }
 
+.item-tags .item-tag:after {
+    content: ', ';
+}
+.item-tags .item-tag:last-child:after {
+    content: '';
+}
+
+
 /* To put duration on its own line, remove this bit. */
 .item-duration {
   display: inline-block;

--- a/src/components/Tag.js
+++ b/src/components/Tag.js
@@ -1,7 +1,7 @@
 import { Format } from '../utils/Format'
 
 const Tag = ({ tag }) => {
-  return <div className="item-tag">{Format.formatTag(tag)},</div>;
+  return <div className="item-tag">{Format.formatTag(tag)}</div>;
 };
 
 export default Tag;


### PR DESCRIPTION
You can see an example of the extra commas in tag lists within items in Arisia's current schedule [here](https://schedule.arisia.org).  

I took the comma out of Tags.js entirely then added it back in with CSS, with which the last one can be removed easily.