### PR TITLE
Prevent help box from creating horizontal scroll

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -226,6 +226,7 @@ header img {
   border-radius: .75rem;
   background-color: var(--help-text-bg);
   color: var(--help-text-fg);
+  box-sizing: border-box;
 }
 
 .help-text button {


### PR DESCRIPTION
Because the width of the help box is 100%, but it also has padding, using the default box sizing, the width is first calculated as 100% of it's container, and then the padding added _on top_ of that, making it wider than it's container. This causes a horizontal scrollbar to appear on small screens, making it hard to scroll with a finger.

Changing the box sizing to `border-box` changes how it calculates the width so it no longer spills outside of it's container.