### PR TITLE
Handle null links property

### DIFF
--- a/src/ProgramData.js
+++ b/src/ProgramData.js
@@ -199,6 +199,8 @@ export class ProgramData {
       for (const item of program) {
         if (
           item.hasOwnProperty("links") &&
+          // handle null links property
+          item.links &&
           item.links.hasOwnProperty(linkToTag.NAME)
         ) {
           item.tags.push(linkToTag.TAG);


### PR DESCRIPTION
Before this pull, the 'links' handling assumed that if there was a "links" property on the item, it was something other than null. This fixes it to check for the existence of the links property before trying to call hasOwnProperty on it, which fails if it's null.