### PR TITLE
Add server-side syncing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+node_modules
 /.pnp
 .pnp.js
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ The main place customisations go is the `src/config.json` file. Settings current
 - `TIME_FORMAT.PM`: Label for PM times.
 - `DURATION.SHOW_DURATION`: If true, `mins` from program data will be displayed.
 - `DURATION.DURATION_LABEL`: Format for duration. `@mins` will be replaced by number of minutes. Note: do not translate `@mins`.
+- `START_TIME.START_TIME_LABEL`: Format for start time with just con time, when read by screen readers. `@con_time` will be replaced by the start time. Note: do not translate `@con_time`.
+- `START_TIME.START_TIME_WITH_LOCAL_LABEL`: Format for start time with both con and local time, when read by screen readers. `@con_time` and `@local_time` will be replaced by the start time. Note: do not translate `@con_time` or `@local_time`.
 - `SHOW_PAST_ITEMS.SHOW_CHECKBOX`: Set to true to show the option during the convention; otherwise past programme items are shown by default.
 - `SHOW_PAST_ITEMS.CHECKBOX_LABEL`: Label for the show past items checkbox.
 - `SHOW_PAST_ITEMS.ADJUST_MINUTES`: Some wiggle room (in minutes) in order not to hide past items immediately as they start.

--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ The main place customisations go is the `src/config.json` file. Settings current
 - `SYNC.LOADING_LABEL`: Label shown while the profile is being fetched on startup.
 - `SYNC.LOGIN_LABEL`: Label for the login link when the user is not authenticated.
 - `SYNC.LOGOUT_LABEL`: Label for the logout link. `@display_name` is replaced with the user's display name.
+- `SYNC.WARNING.HEADING`: Heading of the popup shown the first time an unauthenticated user adds or removes a selection.
+- `SYNC.WARNING.TITLE`: Main message body of the sync warning popup.
+- `SYNC.WARNING.DETAILS`: Expandable detail text shown when the user clicks "More information" in the sync warning popup.
+- `SYNC.WARNING.DETAILS_LABEL`: Label for the button that expands the detail text in the sync warning popup.
+- `SYNC.WARNING.LOGIN_LABEL`: Label for the primary login button in the sync warning popup.
+- `SYNC.WARNING.DISMISS_LABEL`: Label for the dismiss link in the sync warning popup.
 
 More settings will be added to this file in future versions.
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ The main place customisations go is the `src/config.json` file. Settings current
 - `DEBUG_MODE.ONLINE_LABEL`: Label to display in debug mode when online.
 - `DEBUG_MODE.OFFLINE_LABEL`: Label to display in debug mode when offline.
 - `DEBUG_MODE.FETCH_BUTTON_LABEL`: Label to display in debug mode on Fetch button.
+- `SYNC.API_URL`: The base URL of your sync server API (e.g. `https://auth.example-con.org/api`). If omitted or empty, sync is disabled entirely.
+- `SYNC.LOADING_LABEL`: Label shown while the profile is being fetched on startup.
+- `SYNC.LOGIN_LABEL`: Label for the login link when the user is not authenticated.
+- `SYNC.LOGOUT_LABEL`: Label for the logout link. `@display_name` is replaced with the user's display name.
 
 More settings will be added to this file in future versions.
 
@@ -283,6 +287,16 @@ For hosting in a subdirectory, this should be altered as follows:
 The ConClár file format is designed to be compatible with KonOpas, and in most cases data files for KonOpas can be used without modification.
 
 Full details of the file format are in a separate [Data Structure document](https://github.com/lostcarpark/conclar/blob/main/docs/conclar_file_specs.md).
+
+## Syncing selections across devices
+
+By default, users' programme selections are stored only in the browser's local storage. Users can share their schedule between devices using the QR code / link sharing feature on the My Schedule page, without needing any server infrastructure.
+
+If you want selections to sync automatically across devices, you can set up a sync server. When configured, users can log in and their selections will be saved to the server and loaded on any device they sign in to.
+
+To enable sync, add the `SYNC` section to your `config.json` with at least an `API_URL` pointing to your server. See the `SYNC.*` settings in the Customisation section above for the available options. If you don't need sync, simply leave the `SYNC` section out of your config and everything else works as normal.
+
+The sync server API is documented in [docs/sync_server_api.md](docs/sync_server_api.md). You can find an example server in [example-server](example-server), though this should never be used in production.
 
 ## Credits
 

--- a/docs/sync_server_api.md
+++ b/docs/sync_server_api.md
@@ -1,0 +1,268 @@
+# Sync server API
+
+The ConClar programme guide supports syncing a user's selections (favourites) to a server so they are available across
+devices. The server runs on a separate subdomain (e.g. `auth.example.com`) from the SPA (e.g.
+`guide.example.com`).
+
+All merge logic lives in the client. The server stores and retrieves selections.
+Selections are scoped by authenticated user and `app_id`.
+
+## Authentication
+
+Authentication is cookie-based, shared across subdomains.
+
+### Login flow
+
+1. Client renders an `<a>` link to `login_url` (from the profile response) with `<return_url>` replaced.
+2. Auth server authenticates the user (method is server-defined, e.g. OAuth, password, etc.).
+3. Auth server sets a session cookie and redirects back to the programme guide.
+4. SPA reloads, fetches profile, syncs selections.
+
+### Logout flow
+
+1. Client renders an `<a>` link to `logout_url` with `<return_url>` replaced.
+2. Auth server clears the session cookie and redirects back.
+3. Local selections remain intact in the browser.
+
+### Cookie attributes
+
+The session cookie MUST be set with:
+
+```
+Set-Cookie: session=<token>; Domain=.example.com; Path=/; HttpOnly; Secure; SameSite=None
+```
+
+- `Domain=.example.com` -- MUST be the shared parent domain so the cookie is sent to both subdomains
+- `HttpOnly` -- MUST be set to prevent XSS from stealing the session cookie
+- `Secure` -- MUST be set (HTTPS only)
+- `SameSite=None` -- MUST be set for cross-origin credentialed requests to work
+
+### CORS configuration
+
+The SPA makes credentialed cross-origin requests to the API. The server MUST respond with:
+
+```
+Access-Control-Allow-Origin: https://guide.example.com
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Methods: GET, PATCH, OPTIONS
+Access-Control-Allow-Headers: Content-Type
+```
+
+`Access-Control-Allow-Origin` MUST be the exact origin, not `*` -- browsers reject `*` when credentials are included.
+
+If more than one SPA origin is supported, the server SHOULD dynamically echo an allowed origin value and send
+`Vary: Origin`.
+
+### CSRF protection
+
+Because `SameSite=None` means the cookie is sent on cross-origin requests, CSRF is possible. The server MUST check the
+`Origin` header on PATCH requests and reject any that don't match the expected programme guide origin. Modern browsers
+always send `Origin` on CORS requests.
+
+## Endpoints
+
+### Common response error shape
+
+Error response bodies SHOULD use this format across all endpoints:
+
+```json
+{
+  "error": {
+    "code": "invalid_request",
+    "message": "All selection values must be boolean"
+  }
+}
+```
+
+`code` SHOULD be a stable machine-readable string; `message` SHOULD be human-readable and safe to display.
+
+### `GET /profile`
+
+Returns the current authentication state. The client calls this on startup to determine whether to show a login link or
+sync selections.
+
+**Authenticated response:**
+
+```json
+{
+  "authenticated": true,
+  "id": "A0001",
+  "display_name": "alice",
+  "logout_url": "https://auth.example.com/logout?return_to=<return_url>"
+}
+```
+
+**Not authenticated response:**
+
+```json
+{
+  "authenticated": false,
+  "login_url": "https://auth.example.com/login?return_to=<return_url>"
+}
+```
+
+#### `<return_url>` placeholder
+
+The `login_url` and `logout_url` values SHOULD contain the literal string `<return_url>`. The client replaces this
+with `encodeURIComponent(window.location.href)` before navigating, so the user is redirected back to the same page.
+
+When the server receives a request with a return URL, it MUST:
+
+1. Validate it against an allowlist of origins to prevent open redirects.
+2. If valid, redirect to it after completing login/logout.
+3. If invalid or missing, redirect to a sensible default.
+
+### `GET /apps/<app_id>/selections`
+
+Returns all of the user's selections for the specified app.
+
+`app_id` is a required path parameter and SHOULD match the client's configured `APP_ID`.
+
+**Response:**
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "selections": {
+    "item-123": true,
+    "item-456": false
+  }
+}
+```
+
+**Error responses:**
+
+- `400 Bad Request` -- invalid `app_id`
+- `401 Unauthorized` -- session cookie missing or invalid
+- `405 Method Not Allowed` -- unsupported method on this route
+
+### `PATCH /apps/<app_id>/selections`
+
+The client sends changed selection values. The server stores them and returns no response body.
+
+`app_id` is a required path parameter and SHOULD match the client's configured `APP_ID`. The server MAY validate the
+`app_id` against a list of known app ids and return a 400 Bad Request if it is not in the list.
+
+Values in `selections` MUST be JSON booleans (`true` or `false`). Non-boolean values MUST be rejected.
+
+`false` is different from an omitted key. Omitted means “no opinion”; `false` means explicitly not selected. The server
+MUST store and return `false` values explicitly.
+
+The write is atomic: either all provided key/value pairs are persisted, or none are.
+
+#### Request validation rules
+
+For this endpoint, the server MUST enforce all of the following:
+
+- Request `Content-Type` MUST be `application/json`.
+- Body MUST be valid JSON.
+- Body MUST contain a top-level `selections` object.
+- `selections` keys MUST be item IDs (opaque strings).
+- `selections` values MUST be JSON booleans (`true` or `false`).
+
+If `Content-Type` is invalid, the server SHOULD return `415 Unsupported Media Type`.
+If any other rule fails, the server MUST return `400 Bad Request`.
+For all validation failures, the server MUST NOT persist any changes.
+
+An empty object (`{"selections": {}}`) is valid and SHOULD return `204 No Content`.
+
+**Request:**
+
+```
+PATCH /apps/O2021/selections HTTP/1.1
+Content-Type: application/json
+
+{
+  "selections": {
+    "item-123": true,
+    "item-456": false
+  }
+}
+```
+
+**Success response:**
+
+```
+HTTP/1.1 204 No Content
+```
+
+**Error responses:**
+
+- `400 Bad Request` -- invalid `app_id`
+- `400 Bad Request` -- request body is invalid
+  (for example, malformed JSON, missing `selections`, or non-boolean value). No changes are persisted.
+- `401 Unauthorized`
+- `405 Method Not Allowed`
+- `415 Unsupported Media Type` -- content type is not `application/json`
+- `429 Too Many Requests` -- server-side rate limiting (optional)
+- `5xx` -- transient server error
+
+## Limitations
+
+- **Last-writer-wins**: When two devices change the same item, the most recently synced change wins. If device A selects
+  an item and device B deselects it, the result depends on which syncs last, not which action the user performed last.
+  This is acceptable for convention favourites.
+
+- **No real-time sync**: Changes only propagate when a device loads the page. Two devices open simultaneously won't see
+  each other's changes until one reloads. Push-based sync (e.g. WebSockets) is not supported.
+
+## Reference implementation
+
+This section is non-normative and provided as an example only.
+
+### PATCH logic
+
+```js
+function patchSelections(user, request) {
+  const appId = request.params.app_id;
+  if (!appId) {
+    return {
+      status: 400,
+      body: { error: "Invalid app_id" },
+    };
+  }
+
+  // Validate all entries before writing any.
+  const entries = Object.entries(request.body.selections);
+  for (const [, selected] of entries) {
+    if (typeof selected !== "boolean") {
+      return {
+        status: 400,
+        body: { error: "All selection values must be boolean" },
+      };
+    }
+  }
+
+  user.selectionsByApp ||= {};
+  user.selectionsByApp[appId] ||= {};
+
+  for (const [itemId, selected] of entries) {
+    user.selectionsByApp[appId][itemId] = selected;
+  }
+
+  return {
+    status: 204,
+  };
+}
+```
+
+### GET logic
+
+```js
+function getSelections(user, request) {
+  const appId = request.params.app_id;
+  if (!appId) {
+    return {
+      status: 400,
+      body: { error: "Invalid app_id" },
+    };
+  }
+
+  return {
+    status: 200,
+    body: { selections: user.selectionsByApp?.[appId] || {} },
+  };
+}
+```

--- a/example-server/README.md
+++ b/example-server/README.md
@@ -1,0 +1,33 @@
+# Example Sync Server
+
+This is a minimal sync server for demonstration and reference purposes only. It implements the
+[sync server API](../docs/sync_server_api.md) with in-memory storage and a simple name-based login (no real
+authentication).
+
+**Do not use this in production.**
+
+## Running
+
+```sh
+cd example-server
+npm install
+npm start
+```
+
+The server starts on `http://localhost:3001` by default.
+
+## Configuring the app
+
+In `src/config.json`, set the `SYNC.API_URL` to point at the example server:
+
+```json
+{
+  "SYNC": {
+    "API_URL": "http://localhost:3001/api/conclar"
+  }
+}
+```
+
+Then start the app with `npm start` from the project root. The login button in the navigation bar will let you enter a
+display name to log in. Selections will be synced to the example server's in-memory store for the duration of the
+session.

--- a/example-server/package-lock.json
+++ b/example-server/package-lock.json
@@ -1,0 +1,840 @@
+{
+  "name": "conclar-example-sync-server",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "conclar-example-sync-server",
+      "dependencies": {
+        "cookie-parser": "^1.4.7",
+        "escape-html": "^1.0.3",
+        "express": "^4.21.2"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/example-server/package.json
+++ b/example-server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "conclar-example-sync-server",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "cookie-parser": "^1.4.7",
+    "escape-html": "^1.0.3",
+    "express": "^4.21.2"
+  }
+}

--- a/example-server/server.js
+++ b/example-server/server.js
@@ -1,0 +1,218 @@
+import express from "express";
+import cookieParser from "cookie-parser";
+import crypto from "crypto";
+import escapeHtml from "escape-html";
+
+const PORT = 3001;
+const BASE_PATH = "/api/conclar";
+const ALLOWED_ORIGINS = ["http://localhost:3000"];
+
+const app = express();
+app.use(cookieParser());
+
+// --- Session store (in-memory) ---
+
+const sessions = new Map(); // token -> { userId, displayName }
+const users = new Map(); // userId -> { selectionsByApp: { appId: { itemId: bool } } }
+
+function getSession(req) {
+  const token = req.cookies.session;
+  if (!token) {
+    return null;
+  }
+  return sessions.get(token) || null;
+}
+
+function createSession(res, userId, displayName) {
+  const token = crypto.randomBytes(32).toString("hex");
+  sessions.set(token, { userId, displayName });
+  // Production servers should use sameSite: "none" with secure: true (HTTPS).
+  // SameSite=None is needed because the SPA and API are on different subdomains
+  // (cross-origin), and Lax doesn't send cookies on cross-origin fetch requests
+  // like the PATCH to /selections.
+  // For local development, both the SPA and server are on localhost (same-site),
+  // but SameSite=None requires Secure which requires HTTPS. Lax works here
+  // because same-site fetch requests include Lax cookies.
+  res.cookie("session", token, {
+    path: "/",
+    httpOnly: true,
+    sameSite: "lax",
+  });
+  return token;
+}
+
+function destroySession(req, res) {
+  const token = req.cookies.session;
+  if (token) {
+    sessions.delete(token);
+  }
+  res.clearCookie("session", {
+    path: "/",
+    httpOnly: true,
+    sameSite: "lax",
+  });
+}
+
+function getUser(userId) {
+  if (!users.has(userId)) {
+    users.set(userId, { selectionsByApp: {} });
+  }
+  return users.get(userId);
+}
+
+function isAllowedReturnUrl(url) {
+  try {
+    return ALLOWED_ORIGINS.includes(new URL(url).origin);
+  } catch {
+    return false;
+  }
+}
+
+// --- CORS ---
+
+app.use((req, res, next) => {
+  const origin = req.headers.origin;
+  if (ALLOWED_ORIGINS.includes(origin)) {
+    res.set("Access-Control-Allow-Origin", origin);
+    res.set("Access-Control-Allow-Credentials", "true");
+    res.set("Access-Control-Allow-Methods", "GET, PATCH, OPTIONS");
+    res.set("Access-Control-Allow-Headers", "Content-Type");
+    res.set("Vary", "Origin");
+  }
+  if (req.method === "OPTIONS") {
+    return res.sendStatus(204);
+  }
+  next();
+});
+
+// --- Login page ---
+
+app.get(`${BASE_PATH}/login`, (req, res) => {
+  const returnTo = req.query.return_to || "/";
+  res.set("Content-Type", "text/html");
+  res.send(`<!DOCTYPE html>
+<html>
+<head><title>Log in</title></head>
+<body>
+  <h1>Log in</h1>
+  <form method="POST" action="${BASE_PATH}/login">
+    <input type="hidden" name="return_to" value="${escapeHtml(returnTo)}">
+    <label for="name">Display name:</label>
+    <input type="text" id="name" name="name" required autofocus>
+    <button type="submit">Log in</button>
+  </form>
+</body>
+</html>`);
+});
+
+app.post(`${BASE_PATH}/login`, express.urlencoded({ extended: false }), (req, res) => {
+  const name = (req.body.name || "").trim();
+  if (!name) {
+    return res.redirect(`${BASE_PATH}/login?return_to=${encodeURIComponent(req.body.return_to || "/")}`);
+  }
+  createSession(res, name, name);
+  const returnTo = req.body.return_to || "/";
+  if (!isAllowedReturnUrl(returnTo)) {
+    return res.redirect("/");
+  }
+  res.redirect(returnTo);
+});
+
+// --- Logout ---
+
+app.get(`${BASE_PATH}/logout`, (req, res) => {
+  destroySession(req, res);
+  const returnTo = req.query.return_to || "/";
+  if (!isAllowedReturnUrl(returnTo)) {
+    return res.redirect("/");
+  }
+  res.redirect(returnTo);
+});
+
+// --- GET /profile ---
+
+app.get(`${BASE_PATH}/profile`, (req, res) => {
+  const session = getSession(req);
+  if (!session) {
+    res.json({
+      authenticated: false,
+      login_url: `http://localhost:${PORT}${BASE_PATH}/login?return_to=<return_url>`,
+    });
+  }
+  return res.json({
+    authenticated: true,
+    id: session.userId,
+    display_name: session.displayName,
+    logout_url: `http://localhost:${PORT}${BASE_PATH}/logout?return_to=<return_url>`,
+  });
+});
+
+// --- GET /apps/:app_id/selections ---
+
+app.get(`${BASE_PATH}/apps/:app_id/selections`, (req, res) => {
+  const session = getSession(req);
+  if (!session) {
+    return res.status(401).json({ error: { code: "unauthorized", message: "Not authenticated" } });
+  }
+  const appId = req.params.app_id;
+  if (!appId) {
+    return res.status(400).json({ error: { code: "invalid_request", message: "Invalid app_id" } });
+  }
+  const user = getUser(session.userId);
+  res.json({ selections: user.selectionsByApp[appId] || {} });
+});
+
+// --- PATCH /apps/:app_id/selections ---
+
+app.patch(`${BASE_PATH}/apps/:app_id/selections`, express.json(), (req, res) => {
+  // CSRF check
+  const origin = req.headers.origin;
+  if (!ALLOWED_ORIGINS.includes(origin)) {
+    return res.status(403).json({ error: { code: "forbidden", message: "Invalid origin" } });
+  }
+
+  const session = getSession(req);
+  if (!session) {
+    return res.status(401).json({ error: { code: "unauthorized", message: "Not authenticated" } });
+  }
+
+  const appId = req.params.app_id;
+  if (!appId) {
+    return res.status(400).json({ error: { code: "invalid_request", message: "Invalid app_id" } });
+  }
+
+  const contentType = req.headers["content-type"] || "";
+  if (!contentType.includes("application/json")) {
+    return res.status(415).json({ error: { code: "unsupported_media_type", message: "Content-Type must be application/json" } });
+  }
+
+  if (!req.body || typeof req.body.selections !== "object" || req.body.selections === null) {
+    return res.status(400).json({ error: { code: "invalid_request", message: "Body must contain a selections object" } });
+  }
+
+  const entries = Object.entries(req.body.selections);
+  for (const [, selected] of entries) {
+    if (typeof selected !== "boolean") {
+      return res.status(400).json({ error: { code: "invalid_request", message: "All selection values must be boolean" } });
+    }
+  }
+
+  if (entries.length === 0) {
+    return res.sendStatus(204);
+  }
+
+  const user = getUser(session.userId);
+  user.selectionsByApp[appId] ||= {};
+  for (const [itemId, selected] of entries) {
+    user.selectionsByApp[appId][itemId] = selected;
+  }
+
+  res.sendStatus(204);
+});
+
+// --- Start ---
+
+app.listen(PORT, () => {
+  console.log(`Example sync server running at http://localhost:${PORT}`);
+  console.log(`API base path: ${BASE_PATH}`);
+});

--- a/src/App.css
+++ b/src/App.css
@@ -707,6 +707,22 @@ input.switch:checked ~ label:after {
   word-break: break-word;
 }
 
+.item-header {
+    border: none;
+    margin: 0;
+    padding: 0;
+    width: auto;
+    overflow: visible;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    line-height: normal;
+    -webkit-font-smoothing: inherit;
+    -moz-osx-font-smoothing: inherit;
+    -webkit-appearance: none;
+    text-align: inherit;
+}
+
 .item-chevron {
   float: right;
   color: var(--program-item-chevron-collapsed);
@@ -811,6 +827,8 @@ input.switch:checked ~ label:after {
 
 .item-details {
   overflow: hidden;
+  /* Give enough space for the focus ring on the header above. */
+  margin-top: 3px;
 }
 
 /* .item-entry > .item-details.item-details-expanded {

--- a/src/App.css
+++ b/src/App.css
@@ -277,73 +277,69 @@ header img {
 /* 3a. Toggles and Filters.
    style all non-selection checkboxes as toggles
    based on https://www.sitepoint.com/css3-toggle-switch/ */
-
-div.switch-wrapper {
-  font-size: smaller;
-}
-div.switch-wrapper label {
-  max-height: 2em;
-}
-
-div.switch-wrapper,
-div.switch-wrapper ~ div {
-  clear: both;
-  margin: 0.5em 1em;
-}
-
-div.program-empty {
-  clear: both;
-}
-
-input.switch:empty {
-  display: none;
-}
-
-input.switch:empty ~ label {
-  position: relative;
-  float: left;
-  line-height: 1.6em;
-  text-indent: 3.4em;
-  margin: 0.2em 0;
-  cursor: pointer;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
+.switch {
+    border: none;
+    padding: 0.3em;
+    width: auto;
+    overflow: visible;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    -webkit-font-smoothing: inherit;
+    -moz-osx-font-smoothing: inherit;
+    -webkit-appearance: none;
+    text-align: inherit;
+    position: relative;
+    float: left;
+    line-height: 1.6em;
+    text-indent: 3.4em;
+    margin: 0.2em 0;
+    cursor: pointer;
+    -webkit-user-select: none;
+    user-select: none;
 }
 
-input.switch:empty ~ label:before,
-input.switch:empty ~ label:after {
+.switch::before {
   position: absolute;
   display: block;
-  top: 0;
-  bottom: 0;
-  left: 0;
+  top: 0.3em;
+  bottom: 0.3em;
+  left: 0.3em;
   content: " ";
   width: 3em;
   background-color: var(--checkbox-unselected-bg);
   border-radius: 1em;
   box-shadow: inset 0 0.2em 0 var(--shadow-03);
-  -webkit-transition: all 100ms ease-in;
   transition: all 100ms ease-in;
 }
 
-input.switch:empty ~ label:after {
+.switch[aria-checked="true"]::before {
+  background-color: var(--checkbox-selected-bg);
+}
+
+.switch::after {
+  position: absolute;
+  display: block;
+  left: 0.35em;
+  content: " ";
+  width: 3em;
+  transition: all 100ms ease-in;
   width: 1.4em;
-  top: 0.1em;
-  bottom: 0.1em;
+  top: 0.4em;
+  bottom: 0.4em;
   margin-left: 0.1em;
   background-color: var(--checkbox-switch-bg);
   border-radius: 0.9em;
   box-shadow: inset 0 -0.2em 0 var(--shadow-02);
 }
 
-input.switch:checked ~ label:before {
-  background-color: var(--checkbox-selected-bg);
+.switch[aria-checked="true"]::after {
+  margin-left: 1.35em;
 }
 
-input.switch:checked ~ label:after {
-  margin-left: 1.5em;
+div.switch-wrapper {
+  font-size: smaller;
+  margin: .5em 1em;
 }
 
 /* two rews on large screens, seven on tiny */

--- a/src/App.css
+++ b/src/App.css
@@ -759,6 +759,17 @@ input.switch:checked ~ label:after {
   white-space: nowrap;
 }
 
+.item-start-time {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 .item-permalink {
   float: right;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -399,7 +399,14 @@ input.switch:checked ~ label:after {
 }
 
 .filter-hide-before label {
-  display: none;
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
 
 .filter-hide-before select
@@ -424,7 +431,14 @@ input.switch:checked ~ label:after {
 }
 
 .filter-search label {
-  display: none;
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
 
 .filter-container .filter-select__control,
@@ -656,7 +670,14 @@ input.switch:checked ~ label:after {
 }
 
 .selection label {
-  display: none;
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
 
 .item {
@@ -879,7 +900,14 @@ input.switch:checked ~ label:after {
 }
 
 .people-search label {
-  display: none;
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
 }
 
 .people ul {

--- a/src/App.css
+++ b/src/App.css
@@ -733,6 +733,8 @@ div.switch-wrapper {
 
 .item-title {
   font-weight: bold;
+  margin: 0;
+  font-size: inherit;
 }
 
 .item-duration,

--- a/src/App.css
+++ b/src/App.css
@@ -209,6 +209,11 @@ header img {
   white-space: nowrap;
 }
 
+.navigation li a.disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .navigation li a.active {
   background-color: var(--navigation-button-current-bg);
   color: var(--navigation-button-current-fg);
@@ -218,6 +223,11 @@ header img {
 .navigation li a.active:hover {
   background-color: var(--navigation-button-hover-bg);
   color: var(--navigation-button-hover-fg);
+}
+
+.navigation li a.disabled:hover {
+  background-color: var(--navigation-button-bg);
+  color: var(--navigation-button-fg);
 }
 
 .help-text {

--- a/src/App.css
+++ b/src/App.css
@@ -77,9 +77,10 @@
   --participant-link-fg: #000;
   --participant-link-visited-fg: #444;
   --settings-outline: #888;
-  --footer-line: #888;
+  --footer-line: #eee;
   --footer-bg-color: #424242;
   --footer-fg-color: #F5F5F5;
+  --info-popup-details-fg: #555;
   --error-message-fg: tomato;
   --shadow-014: rgba(0, 0, 0, 0.14);
   --shadow-012: rgba(0, 0, 0, 0.12);
@@ -240,6 +241,141 @@ header img {
 
 .help-text button {
   float: right;
+}
+
+/* Info popup */
+.info-popup-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 15vh 0;
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+.info-popup {
+  background: var(--main-bg);
+  color: var(--main-fg);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  max-width: 30rem;
+  width: calc(100% - 2rem);
+  box-shadow: 0 4px 20px var(--shadow-03);
+}
+
+.info-popup-graphic {
+  margin-bottom: 1rem;
+  max-width: 75%;
+  opacity: 0.7;
+}
+
+.info-popup-graphic svg {
+  width: 100%;
+  display: block;
+}
+
+.info-popup-heading {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+  font-size: 1.4rem;
+}
+
+.info-popup-title {
+  margin: 0 0 1rem;
+}
+
+.info-popup-details {
+  margin-bottom: 1rem;
+}
+
+.info-popup-details-toggle {
+  background: none;
+  border: none;
+  color: var(--info-popup-details-fg);
+  cursor: pointer;
+  padding: 0;
+  font-size: inherit;
+  text-decoration: none;
+}
+
+.info-popup-details-toggle:hover {
+  color: var(--info-popup-details-fg);
+}
+
+.info-popup-details-chevron {
+  margin-left: 0.25rem;
+  vertical-align: middle;
+  transition: transform 0.2s ease;
+  opacity: 0.7;
+}
+
+.info-popup-details-content {
+  margin-top: 0.75rem;
+}
+
+.info-popup-divider {
+  border: none;
+  border-top: 1px solid var(--footer-line);
+  margin: 1rem 0;
+}
+
+.info-popup-actions {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.info-popup-primary {
+  background-color: var(--navigation-button-current-bg);
+  color: var(--navigation-button-current-fg);
+  border: none;
+  border-radius: 2rem;
+  padding: 0.75rem 1.5rem;
+  cursor: pointer;
+  font-size: inherit;
+  font-weight: 600;
+  text-decoration: none;
+  display: inline-block;
+}
+
+.info-popup-primary:hover {
+  background-color: var(--navigation-button-hover-bg);
+  color: var(--navigation-button-hover-fg);
+}
+
+.info-popup-dismiss {
+  background: none;
+  border: none;
+  color: var(--link-fg);
+  cursor: pointer;
+  padding: 0;
+  font-size: 0.9rem;
+  text-align: left;
+  text-decoration: underline;
+}
+
+.info-popup-dismiss:hover {
+  color: var(--link-hover-fg);
+}
+
+@media (max-width: 32rem) {
+  .info-popup-overlay {
+    padding: 0;
+    align-items: stretch;
+  }
+
+  .info-popup {
+    max-width: 100%;
+    width: 100%;
+    border-radius: 0;
+    overflow-y: auto;
+  }
 }
 
 @media (max-width: 768px) {

--- a/src/ProgramSelection.js
+++ b/src/ProgramSelection.js
@@ -1,27 +1,46 @@
 import configData from "./config.json";
 
+function getStorageKey(userId) {
+  const storageKey = "selections_" + configData.APP_ID;
+  return userId ? `${storageKey}_${userId}` : storageKey;
+}
+
 export class ProgramSelection {
-  static getAllSelections() {
-    // Get stored selections for application ID.
-    let store = localStorage.getItem("selections_" + configData.APP_ID);
-    if (store) {
-      let selections = JSON.parse(store);
-      if (Array.isArray(selections)) return selections;
+  static getSelectionStore(userId) {
+    const raw = localStorage.getItem(getStorageKey(userId));
+    if (!raw) {
+      return { version: 2, selections: {} };
     }
-    return [];
+    const parsed = JSON.parse(raw);
+    // Migrate from old array format.
+    if (Array.isArray(parsed)) {
+      const selections = {};
+      for (const id of parsed) {
+        selections[id] = { selected: true, dirty: true };
+      }
+      const store = { version: 2, selections };
+      ProgramSelection.setSelectionStore(store, userId);
+      return store;
+    }
+    if (parsed.version === 2) {
+      return parsed;
+    }
+    return { version: 2, selections: {} };
   }
-  static setAllSelections(selections) {
-    localStorage.setItem(
-      "selections_" + configData.APP_ID,
-      JSON.stringify(selections)
+
+  static setSelectionStore(store, userId) {
+    localStorage.setItem(getStorageKey(userId), JSON.stringify(store));
+  }
+
+  static clearSelectionStore(userId) {
+    localStorage.removeItem(getStorageKey(userId));
+  }
+
+  static getSelectedIds(userId) {
+    const store = ProgramSelection.getSelectionStore(userId);
+    return Object.keys(store.selections).filter(
+      (id) => store.selections[id].selected
     );
   }
-  static processMySchedule(program, selectedItems) {
-    let mySchedule = program.filter((item) => {
-      if (selectedItems && selectedItems[item.id])
-        return selectedItems[item.id];
-      return false;
-    });
-    return mySchedule;
-  }
+
 }

--- a/src/SyncService.js
+++ b/src/SyncService.js
@@ -1,0 +1,136 @@
+import configData from "./config.json";
+
+const syncConfig = configData.SYNC || {};
+
+function getApiUrl() {
+  return syncConfig.API_URL || "";
+}
+
+function getAppId() {
+  return configData.APP_ID || "";
+}
+
+function getSelectionsUrl() {
+  const appId = getAppId();
+  if (!appId) {
+    throw new Error("Missing APP_ID in config");
+  }
+  return `${getApiUrl()}/apps/${encodeURIComponent(appId)}/selections`;
+}
+
+function resolveReturnUrl(urlTemplate) {
+  return urlTemplate.replace(
+    "<return_url>",
+    encodeURIComponent(window.location.href)
+  );
+}
+
+export async function fetchProfile() {
+  const response = await fetch(`${getApiUrl()}/profile`, {
+    credentials: "include",
+  });
+  if (!response.ok) {
+    throw new Error(`Profile fetch failed: ${response.status}`);
+  }
+  let data;
+  try {
+    data = await response.json();
+  } catch {
+    throw new Error("Profile response was not valid JSON");
+  }
+  if (typeof data !== "object" || data === null || (!data.login_url && !data.authenticated)) {
+    throw new Error("Profile response has unexpected shape");
+  }
+  if (data.authenticated && (!data.id || !data.display_name)) {
+    throw new Error("Authenticated profile missing required fields");
+  }
+  if (data.login_url) {
+    data.login_url = resolveReturnUrl(data.login_url);
+  }
+  if (data.logout_url) {
+    data.logout_url = resolveReturnUrl(data.logout_url);
+  }
+  return data;
+}
+
+export async function fetchSelections() {
+  const response = await fetch(getSelectionsUrl(), {
+    credentials: "include",
+  });
+  if (response.status === 401) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`Selections fetch failed: ${response.status}`);
+  }
+  const data = await response.json();
+  const selections = {};
+  for (const [id, selected] of Object.entries(data.selections || {})) {
+    selections[id] = { selected: !!selected, dirty: false };
+  }
+  return selections;
+}
+
+export function getDirtySelections(selections) {
+  const dirty = {};
+  for (const [id, entry] of Object.entries(selections)) {
+    if (entry.dirty) {
+      dirty[id] = entry;
+    }
+  }
+  return dirty;
+}
+
+export async function pushSelections(selections) {
+  const body = { selections: {} };
+  for (const [id, entry] of Object.entries(selections)) {
+    body.selections[id] = !!entry.selected;
+  }
+  if (Object.keys(body.selections).length === 0) {
+    return {};
+  }
+  const response = await fetch(getSelectionsUrl(), {
+    method: "PATCH",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (response.status === 401) {
+    return { unauthorized: true };
+  }
+  if (!response.ok) {
+    throw new Error(`Selections push failed: ${response.status}`);
+  }
+  // Mark pushed entries as clean.
+  const clean = {};
+  for (const [id, selected] of Object.entries(body.selections)) {
+    clean[id] = { selected: !!selected, dirty: false };
+  }
+  return { selections: clean };
+}
+
+export function mergeSelections(local, server) {
+  const merged = {};
+  const allIds = new Set([
+    ...Object.keys(local),
+    ...Object.keys(server),
+  ]);
+  for (const id of allIds) {
+    const localEntry = local[id];
+    const serverEntry = server[id];
+    if (!localEntry) {
+      merged[id] = { ...serverEntry };
+    } else if (!serverEntry) {
+      merged[id] = { ...localEntry };
+    } else if (localEntry.dirty) {
+      merged[id] = { ...localEntry };
+    } else {
+      merged[id] = { ...serverEntry };
+    }
+  }
+  return merged;
+}
+
+export function isSyncEnabled() {
+  return !!(syncConfig.API_URL);
+}

--- a/src/components/AppRoutes.js
+++ b/src/components/AppRoutes.js
@@ -69,9 +69,11 @@ const AppRoutes = () => {
   );
 
   const fetchProgram = useStoreActions((actions) => actions.fetchProgram);
+  const fetchProfile = useStoreActions((actions) => actions.fetchProfile);
 
   useEffect(() => {
     fetchProgram(true);
+    fetchProfile();
     // eslint-disable-next-line
   }, []);
 

--- a/src/components/AppRoutes.js
+++ b/src/components/AppRoutes.js
@@ -3,6 +3,8 @@ import { useStoreState, useStoreActions } from "easy-peasy";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 
 import configData from "../config.json";
+import { isSyncEnabled } from "../SyncService";
+import InfoPopup from "./InfoPopup";
 import ThemeSelector from "./ThemeSelector";
 import ScrollToTop from "./ScrollToTop";
 import Timer from "./Timer";
@@ -26,6 +28,9 @@ const AppRoutes = () => {
   const appClasses =
     "App" + (configData.DEBUG_MODE.ENABLE ? " debug-mode" : "");
   const darkMode = useStoreState((state) => state.darkMode);
+  const showSyncWarning = useStoreState((state) => state.showSyncWarning);
+  const userProfile = useStoreState((state) => state.userProfile);
+  const setShowSyncWarning = useStoreActions((actions) => actions.setShowSyncWarning);
   const theApp = configData.INTERACTIVE ? (
     <div className={appClasses}>
       <Timer tick={configData.TIMER.TIMER_TICK_SECS} />
@@ -50,6 +55,51 @@ const AppRoutes = () => {
           <Route path="*" element={<NotFound />} />
         </Routes>
       </Loading>
+      {isSyncEnabled() && (
+        <InfoPopup
+          isOpen={showSyncWarning}
+          graphic={
+            <svg viewBox="0 0 240 90" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+              {/* Laptop screen frame */}
+              <rect x="5" y="5" width="95" height="62" rx="5" fill="none" stroke="currentColor" strokeWidth="2.5" />
+              {/* Laptop screen surface */}
+              <rect x="10" y="10" width="85" height="51" rx="2" fill="currentColor" fillOpacity="0.1" />
+              {/* Laptop base */}
+              <rect x="0" y="67" width="105" height="8" rx="4" fill="currentColor" fillOpacity="0.7" />
+              {/* Dashed line: laptop to lock */}
+              <line x1="103" y1="50" x2="115" y2="50" stroke="currentColor" strokeWidth="2" strokeDasharray="4 3" strokeLinecap="round" />
+              {/* Lock shackle */}
+              <path d="M 121,42 L 121,30 Q 130,22 139,30 L 139,42" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+              {/* Lock body */}
+              <rect x="117" y="40" width="26" height="20" rx="4" fill="none" stroke="currentColor" strokeWidth="2.5" />
+              {/* Keyhole */}
+              <circle cx="130" cy="48" r="2.5" fill="currentColor" fillOpacity="0.6" />
+              <rect x="129" y="50" width="2" height="4" rx="1" fill="currentColor" fillOpacity="0.6" />
+              {/* Dashed line: lock to phone */}
+              <line x1="145" y1="50" x2="157" y2="50" stroke="currentColor" strokeWidth="2" strokeDasharray="4 3" strokeLinecap="round" />
+              {/* Phone body */}
+              <rect x="159" y="5" width="40" height="70" rx="7" fill="none" stroke="currentColor" strokeWidth="2.5" />
+              {/* Phone screen */}
+              <rect x="164" y="18" width="30" height="48" rx="2" fill="currentColor" fillOpacity="0.1" />
+              {/* Phone camera */}
+              <circle cx="179" cy="12" r="2" fill="currentColor" fillOpacity="0.5" />
+              {/* Phone home bar */}
+              <rect x="171" y="70" width="16" height="2.5" rx="1.25" fill="currentColor" fillOpacity="0.5" />
+            </svg>
+          }
+          heading={configData.SYNC.WARNING.HEADING}
+          title={configData.SYNC.WARNING.TITLE}
+          details={configData.SYNC.WARNING.DETAILS}
+          detailsLabel={configData.SYNC.WARNING.DETAILS_LABEL}
+          primaryAction={
+            userProfile && userProfile.login_url
+              ? { label: configData.SYNC.WARNING.LOGIN_LABEL, href: userProfile.login_url }
+              : undefined
+          }
+          dismissLabel={configData.SYNC.WARNING.DISMISS_LABEL}
+          onDismiss={() => setShowSyncWarning(false)}
+        />
+      )}
       <Footer />
     </div>
   ) : (

--- a/src/components/Day.js
+++ b/src/components/Day.js
@@ -42,7 +42,7 @@ const Day = ({ date, items, forceExpanded, now }) => {
 
   return (
     <div className="date">
-      <div className="date-heading">{day}</div>
+      <h2 className="date-heading">{day}</h2>
       <div className="date-items">{rows}</div>
     </div>
   );

--- a/src/components/FilterableProgram.js
+++ b/src/components/FilterableProgram.js
@@ -287,7 +287,7 @@ const FilterableProgram = () => {
 
   return (
     <div>
-      <div className="filter">
+      <div className="filter" role="search">
         <div className="search-filters">
           <div className="filter-locations">
             <ReactSelect

--- a/src/components/InfoPopup.js
+++ b/src/components/InfoPopup.js
@@ -1,0 +1,119 @@
+import { useRef, useEffect, useState } from "react";
+import { IoChevronDownCircle } from "react-icons/io5";
+
+const InfoPopup = ({
+  isOpen,
+  graphic,
+  heading,
+  title,
+  details,
+  detailsLabel,
+  primaryAction,
+  dismissLabel,
+  onDismiss,
+}) => {
+  const [detailsExpanded, setDetailsExpanded] = useState(false);
+  const dialogRef = useRef(null);
+  const onDismissRef = useRef(onDismiss);
+  useEffect(() => {
+    onDismissRef.current = onDismiss;
+  }, [onDismiss]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const dialog = dialogRef.current;
+    if (dialog) {
+      const focusable = dialog.querySelectorAll(
+        'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length > 0) {
+        focusable[0].focus();
+      }
+    }
+
+    function handleKeyDown(e) {
+      if (e.key === "Escape") {
+        onDismissRef.current();
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="info-popup-overlay">
+      <div
+        className="info-popup"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={heading ? "info-popup-heading" : "info-popup-title"}
+        ref={dialogRef}
+      >
+        {heading && (
+          <>
+            <h2 id="info-popup-heading" className="info-popup-heading">
+              {heading}
+            </h2>
+            <hr className="info-popup-divider" />
+          </>
+        )}
+        <p id="info-popup-title" className="info-popup-title">
+          {title}
+        </p>
+        {graphic && <div className="info-popup-graphic">{graphic}</div>}
+        {details && (
+          <div className="info-popup-details">
+            <button
+              aria-expanded={detailsExpanded}
+              className="info-popup-details-toggle"
+              onClick={() => setDetailsExpanded(!detailsExpanded)}
+            >
+              {detailsLabel}
+              <IoChevronDownCircle
+                className="info-popup-details-chevron"
+                style={{ transform: detailsExpanded ? "rotate(180deg)" : "rotate(0deg)" }}
+                aria-hidden="true"
+              />
+            </button>
+            {detailsExpanded && (
+              <div className="info-popup-details-content">{details}</div>
+            )}
+          </div>
+        )}
+        <hr className="info-popup-divider" />
+        <div className="info-popup-actions">
+          {primaryAction && (
+            <a href={primaryAction.href} className="info-popup-primary">
+              {primaryAction.label}
+            </a>
+          )}
+          <button className="info-popup-dismiss" onClick={() => onDismissRef.current()}>
+            {dismissLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default InfoPopup;

--- a/src/components/ItemByIdList.js
+++ b/src/components/ItemByIdList.js
@@ -5,7 +5,7 @@ import ProgramList from "./ProgramList";
 
 const ItemByIdList = () => {
   const { addSelection } = useStoreActions((actions) => ({
-    addSelection: actions.addSelection,
+    addSelection: actions.addSelectionAndSync,
   }));
 
   const params = useParams();

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -1,5 +1,6 @@
 import { NavLink } from "react-router-dom";
 import configData from "../config.json";
+import UserStatus from "./UserStatus";
 
 const Navigation = () => {
   const infoLink =
@@ -37,6 +38,7 @@ const Navigation = () => {
           <NavLink to="/settings">{configData.NAVIGATION.SETTINGS}</NavLink>
         </li>
         {extraLinks}
+        <UserStatus />
       </ul>
     </nav>
   );

--- a/src/components/People.js
+++ b/src/components/People.js
@@ -3,6 +3,7 @@ import { useStoreState, useStoreActions } from "easy-peasy";
 import TagSelectors from "./TagSelectors";
 import ResetButton from "./ResetButton";
 import Participant from "./Participant";
+import Switch from "./Switch";
 import configData from "../config.json";
 
 const People = () => {
@@ -68,35 +69,21 @@ const People = () => {
       ? configData.PEOPLE.THUMBNAILS.CHECKBOX_LABEL
       : configData.USELESS_CHECKBOX.CHECKBOX_LABEL;
   const thumbnailsCheckbox = configData.PEOPLE.THUMBNAILS.SHOW_CHECKBOX ? (
-    <div className="people-thumbnails switch-wrapper">
-      <input
-        id="thumbnails"
-        name="thumbnails"
-        className="switch"
-        type="checkbox"
-        checked={showThumbnails}
-        onChange={(e) => setShowThumbnails(e.target.checked)}
-      />
-      <label htmlFor="thumbnails">{thumbnailCheckboxLabel}</label>
-    </div>
+    <Switch
+      id="thumbnails"
+      label={thumbnailCheckboxLabel}
+      checked={showThumbnails}
+      onChange={setShowThumbnails} />
   ) : (
     ""
   );
 
   const sortCheckbox = configData.PEOPLE.SORT.SHOW_CHECKBOX ? (
-    <div className="people-sort switch-wrapper">
-      <input
-        id="sort_people"
-        name="sort_people"
-        className="switch"
-        type="checkbox"
-        checked={sortByFullName}
-        onChange={(e) => setSortByFullName(e.target.checked)}
-      />
-      <label htmlFor="sort_people">
-        {configData.PEOPLE.SORT.CHECKBOX_LABEL}
-      </label>
-    </div>
+    <Switch
+      id="sort_people"
+      label={configData.PEOPLE.SORT.CHECKBOX_LABEL}
+      checked={sortByFullName}
+      onChange={setSortByFullName} />
   ) : (
     ""
   );
@@ -118,24 +105,28 @@ const People = () => {
 
   return (
     <div className="people">
-      <div className="people-settings">
-        {thumbnailsCheckbox}
-        {sortCheckbox}
-        <TagSelectors
-          tags={personTags}
-          selTags={selTags}
-          setSelTags={setSelTags}
-          tagConfig={configData.PEOPLE.TAGS}
-        />
-        {searchInput}
+      <div role="search">
+        <div className="people-settings">
+          {thumbnailsCheckbox}
+          {sortCheckbox}
+          <TagSelectors
+            tags={personTags}
+            selTags={selTags}
+            setSelTags={setSelTags}
+            tagConfig={configData.PEOPLE.TAGS}
+          />
+          {searchInput}
+        </div>
+        <div className="reset-filters">
+          <ResetButton
+            isFiltered={peopleAreFiltered}
+            resetFilters={resetPeopleFilters}
+          />
+        </div>
       </div>
-      <div className="reset-filters">
-        <ResetButton
-          isFiltered={peopleAreFiltered}
-          resetFilters={resetPeopleFilters}
-        />
-      </div>
-      <ul>{rows}</ul>
+      <main>
+        <ul>{rows}</ul>
+      </main>
     </div>
   );
 };

--- a/src/components/ProgramItem.js
+++ b/src/components/ProgramItem.js
@@ -197,16 +197,18 @@ const ProgramItem = ({ item, forceExpanded, now }) => {
         </div>
       </div>
       <div className="item-entry" onClick={toggleExpanded}>
-        <div className="item-title">
-          {chevron}
-          {item.title}
-        </div>
-        <div className="item-line2">
-          <div className="item-location">{locations}</div>
-          {duration}
-        </div>
-         {detailsVisible && (
-          <animated.div className="item-details" style={itemExpandedStyle}>
+        <button id={'header-' + id} className="item-header" aria-expanded={showExpanded} aria-controls={'details-' + id}>
+          <div className="item-title">
+            {chevron}
+            {item.title}
+          </div>
+          <div className="item-line2">
+            <div className="item-location">{locations}</div>
+            {duration}
+          </div>
+        </button>
+        {detailsVisible && (
+          <animated.div className="item-details" style={itemExpandedStyle} id={'details-' + id} role="region" aria-labelledby={'header-' + id}>
             <div className="item-details-expanded" ref={ref}>
               {permaLink}
               <div className="item-people">

--- a/src/components/ProgramItem.js
+++ b/src/components/ProgramItem.js
@@ -233,10 +233,10 @@ const ProgramItem = ({ item, forceExpanded, now }) => {
       </div>
       <div className="item-entry" onClick={toggleExpanded}>
         <button id={'header-' + id} className="item-header" aria-expanded={showExpanded} aria-controls={'details-' + id}>
-          <div className="item-title">
-            {chevron}
+          <h3 className="item-title">
             {item.title}
-          </div>
+            {chevron}
+          </h3>
           <div className="item-line2">
             <div className="item-location">{locations}</div>
             <div className="item-start-time">{startTime}</div>

--- a/src/components/ProgramItem.js
+++ b/src/components/ProgramItem.js
@@ -13,8 +13,13 @@ import configData from "../config.json";
 import PropTypes from "prop-types";
 import { Temporal } from "@js-temporal/polyfill";
 import { useState, useEffect } from "react";
+import { LocalTime } from "../utils/LocalTime";
 
 const ProgramItem = ({ item, forceExpanded, now }) => {
+  const showLocalTime = useStoreState((state) => state.showLocalTime);
+  const show12HourTime = useStoreState((state) => state.show12HourTime);
+  const timeZoneIsShown = useStoreState((state) => state.timeZoneIsShown);
+
   const selected = useStoreState((state) => state.isSelected(item.id));
   const { addSelection, removeSelection } = useStoreActions((actions) => ({
     addSelection: actions.addSelection,
@@ -147,6 +152,36 @@ const ProgramItem = ({ item, forceExpanded, now }) => {
       ""
     );
 
+  const conTime = LocalTime.formatTimeInConventionTimeZone(
+    item.timeSlot,
+    item.startDateAndTime,
+    show12HourTime,
+    timeZoneIsShown
+  );
+  const localTime =
+    showLocalTime === "always" ||
+    (showLocalTime === "differs" && LocalTime.timezonesDiffer)
+      ? LocalTime.formatTimeInLocalTimeZone(
+          item.timeSlot,
+          item.startDateAndTime,
+          show12HourTime,
+          timeZoneIsShown
+        )
+      : null;
+  console.log(localTime);
+  let startTime;
+  if (localTime) {
+    startTime = configData.START_TIME.START_TIME_WITH_LOCAL_LABEL.replace(
+      "@local_time",
+      localTime
+    ).replace("@con_time", conTime);
+  } else {
+    startTime = configData.START_TIME.START_TIME_LABEL.replace(
+      "@con_time",
+      conTime
+    );
+  }
+
   const [ref, bounds] = useMeasure();
   const showExpanded = !configData.INTERACTIVE || expanded || forceExpanded;
   const [detailsVisible, setDetailsVisible] = useState(showExpanded);
@@ -204,6 +239,7 @@ const ProgramItem = ({ item, forceExpanded, now }) => {
           </div>
           <div className="item-line2">
             <div className="item-location">{locations}</div>
+            <div className="item-start-time">{startTime}</div>
             {duration}
           </div>
         </button>

--- a/src/components/ProgramItem.js
+++ b/src/components/ProgramItem.js
@@ -22,8 +22,8 @@ const ProgramItem = ({ item, forceExpanded, now }) => {
 
   const selected = useStoreState((state) => state.isSelected(item.id));
   const { addSelection, removeSelection } = useStoreActions((actions) => ({
-    addSelection: actions.addSelection,
-    removeSelection: actions.removeSelection,
+    addSelection: actions.addSelectionAndSync,
+    removeSelection: actions.removeSelectionAndSync,
   }));
 
   const expanded = useStoreState((state) => state.isExpanded(item.id));

--- a/src/components/ProgramList.js
+++ b/src/components/ProgramList.js
@@ -65,7 +65,7 @@ const ProgramList = ({ program, forceExpanded }) => {
     />
   );
   const conventionTime = (
-    <div className="time-convention-message">
+    <div className="time-convention-message" aria-hidden="true">
       {configData.CONVENTION_TIME.NOTICE.replace(
         "@timezone",
         configData.TIMEZONE

--- a/src/components/ShowPastItems.js
+++ b/src/components/ShowPastItems.js
@@ -1,6 +1,7 @@
 import { useStoreState, useStoreActions } from "easy-peasy";
 import configData from "../config.json";
 import { LocalTime } from "../utils/LocalTime";
+import Switch from "./Switch";
 
 const ShowPastItems = () => {
   const program = useStoreState((state) => state.program);
@@ -10,19 +11,11 @@ const ShowPastItems = () => {
   );
   return LocalTime.isDuringCon(program) &&
     configData.SHOW_PAST_ITEMS.SHOW_CHECKBOX ? (
-    <div className="past-items-checkbox switch-wrapper">
-      <input
-        id={LocalTime.pastItemsClass}
-        name={LocalTime.pastItemsClass}
-        className="switch"
-        type="checkbox"
-        checked={showPastItems}
-        onChange={(e) => {setShowPastItems(e.target.checked)}}
-      />
-      <label htmlFor={LocalTime.pastItemsClass}>
-        {configData.SHOW_PAST_ITEMS.CHECKBOX_LABEL}
-      </label>
-    </div>
+    <Switch
+      id={LocalTime.pastItemsClass}
+      label={configData.SHOW_PAST_ITEMS.CHECKBOX_LABEL}
+      checked={showPastItems}
+      onChange={setShowPastItems} />
   ) : (
     ""
   );

--- a/src/components/Switch.js
+++ b/src/components/Switch.js
@@ -1,0 +1,16 @@
+const Switch = ({ id, label, checked, onChange }) => (
+  <div class="switch-wrapper">
+    <button
+      className="switch"
+      id={id}
+      name={id}
+      role="checkbox"
+      aria-checked={checked}
+      onClick={(e) => onChange(!checked)}
+    >
+      {label}
+    </button>
+  </div>
+);
+
+export default Switch;

--- a/src/components/TimeSlot.js
+++ b/src/components/TimeSlot.js
@@ -44,7 +44,7 @@ const TimeSlot = ({ timeSlot, dateAndTime, items, forceExpanded, now }) => {
 
   return (
     <div id={dateAndTime.toString()} className="timeslot">
-      <div className={timeSlotClass}>
+      <div className={timeSlotClass} aria-hidden="true">
         <div className="time-wrapper">
           {conTime}
           {localTime}

--- a/src/components/Timer.js
+++ b/src/components/Timer.js
@@ -11,6 +11,18 @@ const Timer = ({ tick }) => {
   const fetchProgram = useStoreActions((actions) => actions.fetchProgram);
 
   useEffect(() => {
+    const handleOnline = () => setOnLine(true);
+    const handleOffline = () => setOnLine(false);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, [setOnLine]);
+
+  useEffect(() => {
     // Create JavaScript interval timer.
     let timer = setInterval(() => {
       updateTimeSinceLastFetch();

--- a/src/components/UserStatus.js
+++ b/src/components/UserStatus.js
@@ -1,0 +1,65 @@
+import { useStoreState } from "easy-peasy";
+import configData from "../config.json";
+import { isSyncEnabled } from "../SyncService";
+
+const syncConfig = configData.SYNC || {};
+
+const UserStatus = () => {
+  const userProfile = useStoreState((state) => state.userProfile);
+
+  if (!isSyncEnabled()) {
+    return null;
+  }
+
+  if (!userProfile) {
+    return (
+      <li>
+        <a className="disabled" aria-disabled="true">
+          {syncConfig.LOADING_LABEL || "Loading..."}
+        </a>
+      </li>
+    );
+  }
+
+  if (userProfile.error) {
+    const errorMessage = syncConfig.ERROR_LABEL || "Could not connect to sync server";
+    return (
+      <li>
+        <a className="disabled" aria-disabled="true"
+           role="alert"
+           title={errorMessage}
+           aria-label={errorMessage}>
+          <span aria-hidden="true">⚠ </span>
+          {syncConfig.LOGIN_LABEL || "Log in"}
+        </a>
+      </li>
+    );
+  }
+
+  if (userProfile.authenticated) {
+    const MAX_NAME_LENGTH = 20;
+    const displayName =
+      userProfile.display_name.length > MAX_NAME_LENGTH
+        ? userProfile.display_name.slice(0, MAX_NAME_LENGTH) + "\u2026"
+        : userProfile.display_name;
+    const label = (syncConfig.LOGOUT_LABEL || "Log out @display_name").replace(
+      "@display_name",
+      displayName
+    );
+    return (
+      <li>
+        <a href={userProfile.logout_url}>{label}</a>
+      </li>
+    );
+  }
+
+  return (
+    <li>
+      <a href={userProfile.login_url}>
+        {syncConfig.LOGIN_LABEL || "Log in"}
+      </a>
+    </li>
+  );
+};
+
+export default UserStatus;

--- a/src/config_example.json
+++ b/src/config_example.json
@@ -181,6 +181,10 @@
     "SHOW_DURATION": true,
     "DURATION_LABEL": "Duration: @mins mins"
   },
+  "START_TIME": {
+    "START_TIME_LABEL": "Starts: @con_time",
+    "START_TIME_WITH_LOCAL_LABEL": "Starts: @con_time con time, @local_time local time"
+  },
   "SHOW_PAST_ITEMS": {
     "SHOW_CHECKBOX": true,
     "CHECKBOX_LABEL": "Show past items",

--- a/src/config_example.json
+++ b/src/config_example.json
@@ -279,5 +279,12 @@
     "ONLINE_LABEL": "Currently Online",
     "OFFLINE_LABEL": "Currently Offline",
     "FETCH_BUTTON_LABEL": "Fetch Data Now"
+  },
+  "SYNC": {
+    "API_URL": "https://localhost:3001/api/conclar",
+    "LOADING_LABEL": "Loading...",
+    "LOGIN_LABEL": "Log in",
+    "LOGOUT_LABEL": "Log out @display_name",
+    "ERROR_LABEL": "Could not connect to sync server"
   }
 }

--- a/src/model.js
+++ b/src/model.js
@@ -13,6 +13,8 @@ function getSelectedIdsFromStore(selectionStore) {
 
 let pushInFlight = null;
 let pushNeeded = false;
+const SYNC_WARNING_KEY = "sync_warning_dismissed_" + configData.APP_ID;
+let syncWarningShown = !!localStorage.getItem(SYNC_WARNING_KEY);
 
 async function coalescedSync(actions) {
   if (pushInFlight) {
@@ -80,6 +82,7 @@ const model = {
   sortByFullName: localStorage.getItem("sort_people") === "true" ? true : false,
   onLine: window.navigator.onLine,
   darkMode: localStorage.getItem("dark_mode") ? localStorage.getItem("dark_mode") : 'browser',
+  showSyncWarning: false,
   // Thunks
   fetchProgram: thunk(async (actions, firstTime) => {
     actions.setData(await ProgramData.fetchData(firstTime));
@@ -343,13 +346,35 @@ const model = {
     updateLocalStore(state.selectionStore, state.currentUserId);
   }),
 
+  setShowSyncWarning: action((state, show) => {
+    state.showSyncWarning = show;
+    if (!show) {
+      localStorage.setItem(SYNC_WARNING_KEY, "true");
+      syncWarningShown = true;
+    }
+  }),
+
   // Thunks for sync-aware selection changes.
-  addSelectionAndSync: thunk(async (actions, id) => {
+  addSelectionAndSync: thunk(async (actions, id, { getState }) => {
     actions.addSelection(id);
+    if (SyncService.isSyncEnabled() && !syncWarningShown) {
+      const state = getState();
+      if (state.userProfile && !state.userProfile.authenticated && !state.userProfile.error) {
+        syncWarningShown = true;
+        actions.setShowSyncWarning(true);
+      }
+    }
     await coalescedSync(actions);
   }),
-  removeSelectionAndSync: thunk(async (actions, id) => {
+  removeSelectionAndSync: thunk(async (actions, id, { getState }) => {
     actions.removeSelection(id);
+    if (SyncService.isSyncEnabled() && !syncWarningShown) {
+      const state = getState();
+      if (state.userProfile && !state.userProfile.authenticated && !state.userProfile.error) {
+        syncWarningShown = true;
+        actions.setShowSyncWarning(true);
+      }
+    }
     await coalescedSync(actions);
   }),
 

--- a/src/model.js
+++ b/src/model.js
@@ -2,7 +2,47 @@ import { action, thunk, computed } from "easy-peasy";
 import { ProgramData } from "./ProgramData";
 import { ProgramSelection } from "./ProgramSelection";
 import { LocalTime } from "./utils/LocalTime";
+import * as SyncService from "./SyncService";
 import configData from "./config.json";
+
+function getSelectedIdsFromStore(selectionStore) {
+  return Object.keys(selectionStore).filter(
+    (id) => selectionStore[id].selected
+  );
+}
+
+let pushInFlight = null;
+let pushNeeded = false;
+
+async function coalescedSync(actions) {
+  if (pushInFlight) {
+    // A push is already running. Flag that another is needed and wait.
+    pushNeeded = true;
+    await pushInFlight;
+    return;
+  }
+
+  async function run() {
+    do {
+      pushNeeded = false;
+      await actions.syncSelections();
+    } while (pushNeeded);
+  }
+
+  pushInFlight = run();
+  try {
+    await pushInFlight;
+  } finally {
+    pushInFlight = null;
+  }
+}
+
+function updateLocalStore(selectionStore, userId) {
+  ProgramSelection.setSelectionStore(
+    { version: 2, selections: selectionStore },
+    userId
+  );
+}
 
 const model = {
   isLoading: true,
@@ -26,7 +66,10 @@ const model = {
   showPastItems: LocalTime.getStoredPastItems(),
   expandedItems: [],
   programDisplayLimit: localStorage.getItem("program_display_limit"),
-  mySelections: ProgramSelection.getAllSelections(),
+  selectionStore: ProgramSelection.getSelectionStore().selections,
+  mySelections: ProgramSelection.getSelectedIds(),
+  currentUserId: null,
+  userProfile: null,
   programSelectedLocations: [],
   programSelectedTags: {},
   programHideBefore: "",
@@ -44,6 +87,88 @@ const model = {
     actions.updateTimeSinceLastFetch();
     actions.setIsLoadingFalse();
   }),
+
+  // Sync thunks
+  fetchProfile: thunk(async (actions) => {
+    if (!SyncService.isSyncEnabled()) {
+      return;
+    }
+    try {
+      const profile = await SyncService.fetchProfile();
+      actions.setUserProfile(profile);
+      if (profile.authenticated) {
+        const userId = profile.id;
+        actions.setCurrentUserId(userId);
+
+        // Migrate anonymous selections into the user-specific store.
+        // Only carry over true selections — false values from anonymous browsing
+        // should not override the user's actual server state.
+        const anonStore = ProgramSelection.getSelectionStore().selections;
+        const anonSelections = Object.fromEntries(
+          Object.entries(anonStore).filter(([, entry]) => entry.selected)
+        );
+        const userStore = ProgramSelection.getSelectionStore(userId).selections;
+        const merged = SyncService.mergeSelections(anonSelections, userStore);
+        actions.setSelectionStore(merged);
+        ProgramSelection.clearSelectionStore();
+
+        await actions.syncSelections({ fullSync: true });
+      } else {
+        actions.setCurrentUserId(null);
+        const anonStore = ProgramSelection.getSelectionStore().selections;
+        actions.setSelectionStore(anonStore);
+      }
+    } catch (e) {
+      console.warn("Profile fetch failed:", e);
+      actions.setUserProfile({ error: true });
+    }
+  }),
+
+  syncSelections: thunk(async (actions, payload, { getState }) => {
+    if (!SyncService.isSyncEnabled()) {
+      return;
+    }
+    const state = getState();
+    if (!state.userProfile || !state.userProfile.authenticated) {
+      return;
+    }
+    const fullSync = payload && payload.fullSync;
+    try {
+      // On full sync (page load), GET and merge everything from the server
+      // so the user sees other devices' changes.
+      if (fullSync) {
+        const serverSelections = await SyncService.fetchSelections();
+        if (!serverSelections) {
+          return;
+        }
+        // Start from server state, then layer any unsynced local changes on top.
+        const localDirty = SyncService.getDirtySelections(getState().selectionStore);
+        const merged = { ...serverSelections, ...localDirty };
+        actions.setSelectionStore(merged);
+      }
+
+      const localStore = getState().selectionStore;
+      const dirty = SyncService.getDirtySelections(localStore);
+      const pushResult = await SyncService.pushSelections(dirty);
+      if (pushResult.unauthorized) {
+        return;
+      }
+      if (pushResult.selections) {
+        const current = getState().selectionStore;
+        const updated = { ...current };
+        for (const [id, entry] of Object.entries(pushResult.selections)) {
+          // Only update entries that haven't changed since the push started.
+          if (current[id].selected === dirty[id].selected) {
+            updated[id] = entry;
+          }
+        }
+        actions.setSelectionStore(updated);
+      }
+    } catch (e) {
+      console.warn("Selection sync failed:", e);
+    }
+  }),
+
   // Actions.
   setIsLoadingFalse: action((state) => (state.isLoading = false)),
   setData: action((state, data) => {
@@ -102,7 +227,14 @@ const model = {
     state.sortByFullName = sortByFullName;
     localStorage.setItem("sort_people", sortByFullName ? "true" : "false");
   }),
-  setOnLine: action((state, onLine) => {
+  setOnLine: thunk(async (actions, onLine, { getState }) => {
+    const wasOffline = !getState().onLine;
+    actions._setOnLine(onLine);
+    if (wasOffline && onLine) {
+      await actions.syncSelections({ fullSync: true });
+    }
+  }),
+  _setOnLine: action((state, onLine) => {
     state.onLine = onLine;
   }),
   setDarkMode: action((state, darkMode) => {
@@ -182,18 +314,43 @@ const model = {
   }),
 
   // Actions for selected items.
+  setSelectionStore: action((state, selections) => {
+    state.selectionStore = selections;
+    state.mySelections = getSelectedIdsFromStore(selections);
+    updateLocalStore(selections, state.currentUserId);
+  }),
+  setCurrentUserId: action((state, userId) => {
+    state.currentUserId = userId;
+  }),
+  setUserProfile: action((state, profile) => {
+    state.userProfile = profile;
+  }),
   setSelection: action((state, selection) => {
     state.mySelections = selection;
   }),
   addSelection: action((state, id) => {
-    state.mySelections.push(id);
-    ProgramSelection.setAllSelections(state.mySelections); // ToDo: Move sude effect to thunk.
+    if (!state.mySelections.includes(id)) {
+      state.mySelections.push(id);
+    }
+    state.selectionStore[id] = { selected: true, dirty: true };
+    updateLocalStore(state.selectionStore, state.currentUserId);
   }),
   removeSelection: action((state, id) => {
     state.mySelections = state.mySelections.filter(
       (selection) => selection !== id
     );
-    ProgramSelection.setAllSelections(state.mySelections);
+    state.selectionStore[id] = { selected: false, dirty: true };
+    updateLocalStore(state.selectionStore, state.currentUserId);
+  }),
+
+  // Thunks for sync-aware selection changes.
+  addSelectionAndSync: thunk(async (actions, id) => {
+    actions.addSelection(id);
+    await coalescedSync(actions);
+  }),
+  removeSelectionAndSync: thunk(async (actions, id) => {
+    actions.removeSelection(id);
+    await coalescedSync(actions);
   }),
 
   // Computed.


### PR DESCRIPTION
Add the ability to (optionally) sync with a server. See /docs/_server_api.md for details on the protocol.

This uses a last-write-wins approach to handling merge conflicts. This does mean that if someone does a bunch of changes in both an online and an offline instance, and then syncs the offline instance, the changes in the offline instance will win, even if chronologically they happened before the online instance. However, this is an unlikely use-case, and allows us to have a much simpler solution than something more complex like an or-set CRDT, and avoids issues with clock drift that using timestamps introduces (which present an ongoing sync issue rather than just at the point you bring one online).