### PR TITLE
Remove "Glasgow 2024" from meta description

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Glasgow 2024 Programme Guide"
+      content="Programme Guide"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--


### PR DESCRIPTION
Just leave it as the generic "Programme guide". If a con wants to update it to be more specific, they can. But so many times people forget to change it, and having the name of a different con is more embarrassing than having no name.

Ideally we'd render it from the config.json, but that would require adding a post-processing step which complicates the build process for not much gain.