### PR TITLE
Pop out info links using rehype plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-spring": "^9.4.2",
     "react-timezone-select": "^1.3.1",
     "react-use-measure": "^2.1.1",
+    "rehype-external-links": "^3.0.0",
     "remark-gfm": "^3.0.1",
     "timezone-soft": "^1.4.1",
     "web-vitals": "^2.1.2"

--- a/src/components/Info.js
+++ b/src/components/Info.js
@@ -1,13 +1,14 @@
 import { useStoreState } from "easy-peasy";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import rehypeExternalLinks from "rehype-external-links";
 
 const Info = () => {
   const info = useStoreState((state) => state.info);
 
   return (
     <div className="info">
-      <ReactMarkdown children={info} remarkPlugins={[remarkGfm]} />
+      <ReactMarkdown children={info} remarkPlugins={[remarkGfm]} rehypePlugins={[[rehypeExternalLinks, {target: '_blank'}]]} />
     </div>
   );
 };


### PR DESCRIPTION
This adds target="_blank" to any links parsed out of info.md, because navigating away from ConClar can be problematic in some situations (like home screen apps).  It would be even better if it were configurable, but failing that I think it's better to pop out than not.

This PR does not fix any unrelated issues on the main branch; I tested it on a nearby branch.