### PR TITLE
Add lazy loading of participant images

### DIFF
--- a/src/components/Participant.js
+++ b/src/components/Participant.js
@@ -11,6 +11,7 @@ const Participant = ({ person, thumbnails, moderator }) => {
             <img
               src={person.img}
               alt=""
+              loading="lazy"
               onError={({ currentTarget }) => {
                 currentTarget.onerror = null;
                 currentTarget.style.display = "none";


### PR DESCRIPTION
This one-liner requests lazy loading of participant headshots by the browser. It seems to have improved our bandwidth issues to some degree, though more caching and optimization of images would also be helpful. (ConClar isn't serving the images, so that part is not a ConClar concern.)

In the long term, it might be helpful if the data format and code supported separate thumbnails for participants, for use in the schedule and the People list.

(Copied from my messier PR.)