### PR TITLE
Rename share-body -> share-panel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1019,7 +1019,7 @@ div.switch-wrapper {
   font-size: 1.1em;
 }
 
-.share-body {
+.share-panel {
   margin-bottom: 0.25rem;
 }
 

--- a/src/components/ShareLink.js
+++ b/src/components/ShareLink.js
@@ -13,7 +13,7 @@ const ShareLink = () => {
     const link = window.publicUrl + "ids/" + linkItems;
     const absLink = `${window.location.origin}${link}`;
     links.push(
-      <div key={key++} className="share-body">
+      <div key={key++} className="share-panel">
         <div className="share-link">
           <Link to={link}>
             {multi
@@ -47,7 +47,7 @@ const ShareLink = () => {
 
   const multipleDesc =
     key > 1 ? (
-      <div className="share-body">
+      <div className="share-panel">
         {configData.PROGRAM.MY_SCHEDULE.SHARE.MULTIPLE_DESCRIPTION}
       </div>
     ) : (
@@ -59,7 +59,7 @@ const ShareLink = () => {
       <div className="share-head">
         {configData.PROGRAM.MY_SCHEDULE.SHARE.LABEL}
       </div>
-      <div className="share-body">
+      <div className="share-panel">
         {configData.PROGRAM.MY_SCHEDULE.SHARE.DESCRIPTION}
       </div>
       {multipleDesc}


### PR DESCRIPTION
It was reported that the CSS class `share-body` triggers 1Blocker to prevent the QR codes from showing. Trying out renaming it to `share-panel` to see if that avoids tripping it.

Fixes #133