### PR TITLE
Escape locations in filter URLs

### DIFF
--- a/src/components/FilterableProgram.js
+++ b/src/components/FilterableProgram.js
@@ -301,7 +301,7 @@ const FilterableProgram = () => {
                 resetDisplayLimit();
                 setSelLoc(value);
                 if (value.length) {
-                  const locList = value.map((location) => location.value).join('~');
+                  const locList = value.map((location) => encodeURIComponent(location.value)).join('~');
                   navigate('/loc/' + locList);
                 }
                 else {

--- a/src/components/LocationProgramme.js
+++ b/src/components/LocationProgramme.js
@@ -8,7 +8,7 @@ const LocationProgramme = () => {
   );
 
   const params = useParams();
-  const locations = params.locList.split("~");
+  const locations = params.locList.split("~").map((loc) => decodeURIComponent(loc));
   if (locations.length) {
     setSelLoc(locations.map((loc) => { return {value: loc, label: loc}; }));
   }


### PR DESCRIPTION
When constructing the filter URLs, URL escape the location.

Fixes #183