### PR TITLE
Allow locations to be grouped into venues

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ The main place customisations go is the `src/config.json` file. Settings current
 - `LOCATIONS.SEARCHABLE`: Whether the location list can be searched by typing. (Searching can be inconvenient on touch screens.)
 - `LOCATIONS.LABEL`: Label to show on map links.
 - `LOCATIONS.MAPPING`: Array of locations, with links to show on map. Each room should be specified as: `{ "KEY": "Room name", "MAP_URL": "link to map" }`.
+- `VENUES`: Groups locations by venue, for conventions spanning more than one building. If omitted, the locations drop-down is a flat, ungrouped list.
+  - `VENUES.ALL_LABEL`: Label template for the "select this whole venue" option shown at the top of each venue's group in the locations drop-down. `@venue` is replaced with the venue name. Defaults to `"All @venue"`.
+  - `VENUES.UNGROUPED_LABEL`: Label for the group heading shown above locations that aren't listed under any venue. Defaults to `"Other"`.
+  - `VENUES.MAPPING`: Array of venues, each specified as: `{ "NAME": "Venue name", "LOCATIONS": ["Room name", "Another room"] }`. Venues are listed in the locations drop-down in the order given here. A location may only belong to one venue; locations not listed under any venue are shown grouped under `VENUES.UNGROUPED_LABEL`, below the venue groups. Selecting a venue's "All <venue>" option shows every programme item in any of that venue's locations.
 - `APPLICATION.LOADING.MESSAGE`: Message to display while loading.
 - `PROGRAM.LIMIT.SHOW`: If true, "limit number of items" drop-down will be displayed.
 - `PROGRAM.LIMIT.LABEL`: Label for limit drop-down.

--- a/src/App.css
+++ b/src/App.css
@@ -897,6 +897,10 @@ div.switch-wrapper {
   margin-right: 0.5rem;
 }
 
+.item-location-venue {
+  opacity: 0.75;
+}
+
 .item-tags .item-tag:after {
     content: ', ';
 }

--- a/src/components/FilterableProgram.jsx
+++ b/src/components/FilterableProgram.jsx
@@ -9,6 +9,7 @@ import ResetButton from "./ResetButton";
 import ProgramList from "./ProgramList";
 import ShowPastItems from "./ShowPastItems";
 import { LocalTime } from "../utils/LocalTime";
+import { buildLocationOptions, locationMatchesSelection } from "../utils/Venues";
 
 const FilterableProgram = () => {
   const navigate = useNavigate();
@@ -142,7 +143,7 @@ const FilterableProgram = () => {
       filtered = filtered.filter((item) => {
         for (const location of item.loc) {
           for (const selected of selLoc) {
-            if (selected.value === location) return true;
+            if (locationMatchesSelection(location, selected.value, configData)) return true;
           }
         }
         return false;
@@ -292,7 +293,7 @@ const FilterableProgram = () => {
           <div className="filter-locations">
             <ReactSelect
               placeholder="Select locations"
-              options={locations}
+              options={buildLocationOptions(locations, configData)}
               isMulti
               isSearchable={configData.LOCATIONS.SEARCHABLE}
               value={selLoc}

--- a/src/components/Location.jsx
+++ b/src/components/Location.jsx
@@ -1,5 +1,11 @@
-const Location = ({ loc }) => {
-  return <span>{loc}, </span>;
+const Location = ({ loc, venue }) => {
+  return (
+    <span>
+      {loc}
+      {venue ? <span className="item-location-venue"> ({venue})</span> : ""}
+      {", "}
+    </span>
+  );
 };
 
 export default Location;

--- a/src/components/LocationProgramme.jsx
+++ b/src/components/LocationProgramme.jsx
@@ -1,6 +1,8 @@
 import { useStoreActions } from "easy-peasy";
 import { useParams } from "react-router-dom";
 import FilterableProgram from "./FilterableProgram";
+import configData from "../config.json";
+import { labelForLocationValue } from "../utils/Venues";
 
 const LocationProgramme = () => {
   const setSelLoc = useStoreActions(
@@ -10,7 +12,9 @@ const LocationProgramme = () => {
   const params = useParams();
   const locations = params.locList.split("~").map((loc) => decodeURIComponent(loc));
   if (locations.length) {
-    setSelLoc(locations.map((loc) => { return {value: loc, label: loc}; }));
+    setSelLoc(locations.map((loc) => {
+      return { value: loc, label: labelForLocationValue(loc, configData) };
+    }));
   }
 
   return (

--- a/src/components/ProgramItem.jsx
+++ b/src/components/ProgramItem.jsx
@@ -14,6 +14,7 @@ import PropTypes from "prop-types";
 import { Temporal } from "@js-temporal/polyfill";
 import { useState, useEffect } from "react";
 import { LocalTime } from "../utils/LocalTime";
+import { venueForLocation } from "../utils/Venues";
 
 const ProgramItem = ({ item, forceExpanded = false, now }) => {
   const showLocalTime = useStoreState((state) => state.showLocalTime);
@@ -64,9 +65,9 @@ const ProgramItem = ({ item, forceExpanded = false, now }) => {
   const locations = [];
   if (Array.isArray(item.loc))
     for (let loc of item.loc) {
-      locations.push(<Location key={loc} loc={loc} />);
+      locations.push(<Location key={loc} loc={loc} venue={venueForLocation(loc, configData)} />);
     }
-  else locations.push(<Location key={item.loc} loc={item.loc} />);
+  else locations.push(<Location key={item.loc} loc={item.loc} venue={venueForLocation(item.loc, configData)} />);
 
   const permaLink =
     configData.PERMALINK.SHOW_PERMALINK && configData.INTERACTIVE ? (

--- a/src/config_example.json
+++ b/src/config_example.json
@@ -47,6 +47,13 @@
       { "KEY": "Davin - Croke Park", "MAP_URL": "https://map.octocon.com" }
     ]
   },
+  "VENUES": {
+    "ALL_LABEL": "All @venue",
+    "UNGROUPED_LABEL": "Other",
+    "MAPPING": [
+      { "NAME": "Convention Center", "LOCATIONS": ["Davin - Croke Park"] }
+    ]
+  },
   "APPLICATION": {
     "LOADING": {
       "MESSAGE": "Loading... Please wait..."

--- a/src/utils/Venues.js
+++ b/src/utils/Venues.js
@@ -1,0 +1,143 @@
+const VENUE_VALUE_PREFIX = "venue:";
+
+/**
+ * Whether config.json defines any venues.
+ *
+ * @param {object} configData Parsed config.json.
+ * @returns {boolean}
+ */
+export function hasVenues(configData) {
+  return !!(
+    configData.VENUES &&
+    Array.isArray(configData.VENUES.MAPPING) &&
+    configData.VENUES.MAPPING.length
+  );
+}
+
+/**
+ * The react-select option value used for a venue's "All <venue>" pseudo-option.
+ *
+ * @param {string} venueName
+ * @returns {string}
+ */
+export function venueOptionValue(venueName) {
+  return VENUE_VALUE_PREFIX + venueName;
+}
+
+/**
+ * Whether a react-select option value refers to a venue (rather than a location).
+ *
+ * @param {string} value
+ * @returns {boolean}
+ */
+export function isVenueValue(value) {
+  return typeof value === "string" && value.startsWith(VENUE_VALUE_PREFIX);
+}
+
+/**
+ * Extract the venue name from a venue option value.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+export function venueNameFromValue(value) {
+  return value.slice(VENUE_VALUE_PREFIX.length);
+}
+
+/**
+ * Build the "All <venue>" label for a venue, using the configured template.
+ *
+ * @param {object} configData Parsed config.json.
+ * @param {string} venueName
+ * @returns {string}
+ */
+export function allVenueLabel(configData, venueName) {
+  const template = (configData.VENUES && configData.VENUES.ALL_LABEL) || "All @venue";
+  return template.replace("@venue", venueName);
+}
+
+/**
+ * Find the venue a location belongs to, if any.
+ *
+ * @param {string} loc Location name.
+ * @param {object} configData Parsed config.json.
+ * @returns {?string} The venue name, or null if the location isn't mapped to a venue.
+ */
+export function venueForLocation(loc, configData) {
+  if (!hasVenues(configData)) return null;
+  const venue = configData.VENUES.MAPPING.find((v) => v.LOCATIONS.includes(loc));
+  return venue ? venue.NAME : null;
+}
+
+/**
+ * Build react-select options for the locations dropdown, grouped by venue.
+ * Each venue group is headed by an "All <venue>" pseudo-option, followed by
+ * that venue's locations. Locations not belonging to any venue are appended
+ * as a trailing, unheaded group. If no venues are configured, returns the
+ * locations unchanged (a single flat list).
+ *
+ * @param {Array<{value: string, label: string}>} locations Locations present in the loaded program.
+ * @param {object} configData Parsed config.json.
+ * @returns {Array} react-select options, possibly grouped.
+ */
+export function buildLocationOptions(locations, configData) {
+  if (!hasVenues(configData)) return locations;
+
+  const usedLocations = new Set();
+  const groups = configData.VENUES.MAPPING.map((venue) => {
+    const venueLocations = locations
+      .filter((loc) => venue.LOCATIONS.includes(loc.value))
+      .sort((a, b) => a.value.localeCompare(b.value));
+    venueLocations.forEach((loc) => usedLocations.add(loc.value));
+    return {
+      label: venue.NAME,
+      options: [
+        { value: venueOptionValue(venue.NAME), label: allVenueLabel(configData, venue.NAME) },
+        ...venueLocations,
+      ],
+    };
+  });
+
+  const ungrouped = locations.filter((loc) => !usedLocations.has(loc.value));
+  if (ungrouped.length) {
+    const label =
+      (configData.VENUES && configData.VENUES.UNGROUPED_LABEL) || "Other";
+    groups.push({ label, options: ungrouped });
+  }
+  return groups;
+}
+
+/**
+ * Whether a program item's location matches a selected locations-dropdown value,
+ * expanding venue values ("venue:Marriott") to all locations in that venue.
+ *
+ * @param {string} itemLoc A single location from a program item's loc array.
+ * @param {string} selectedValue A value from the selected-locations dropdown state.
+ * @param {object} configData Parsed config.json.
+ * @returns {boolean}
+ */
+export function locationMatchesSelection(itemLoc, selectedValue, configData) {
+  if (isVenueValue(selectedValue)) {
+    const venueName = venueNameFromValue(selectedValue);
+    const venue = hasVenues(configData)
+      ? configData.VENUES.MAPPING.find((v) => v.NAME === venueName)
+      : undefined;
+    return venue ? venue.LOCATIONS.includes(itemLoc) : false;
+  }
+  return selectedValue === itemLoc;
+}
+
+/**
+ * Reconstruct the display label for a locations-dropdown value, e.g. when
+ * restoring selections from the /loc/:locList URL.
+ *
+ * @param {string} value
+ * @param {object} configData Parsed config.json.
+ * @returns {string}
+ */
+export function labelForLocationValue(value, configData) {
+  if (isVenueValue(value)) {
+    return allVenueLabel(configData, venueNameFromValue(value));
+  }
+  return value;
+}

--- a/src/validateConfig.js
+++ b/src/validateConfig.js
@@ -12,6 +12,7 @@
 export function validateConfig(configData) {
   const errors = [];
   validateDataSourceConfig(configData, errors);
+  validateVenuesConfig(configData, errors);
   if (errors.length > 0) {
     throw new Error(
       "Invalid config.json:\n - " + errors.join("\n - ")
@@ -59,6 +60,58 @@ function validateDataSourceConfig(configData, errors) {
       errors.push(
         "DATA_URLS must specify COMBINED, or both SCHEDULE and PEOPLE."
       );
+    }
+  }
+}
+
+/**
+ * Validate the optional VENUES config block. Each venue must have a non-empty
+ * NAME and a non-empty LOCATIONS array of strings. Venue names must be unique,
+ * and a location may not be assigned to more than one venue.
+ *
+ * @param {object} configData Parsed contents of config.json.
+ * @param {string[]} errors Accumulator for problem descriptions.
+ */
+function validateVenuesConfig(configData, errors) {
+  if (configData.VENUES === undefined) return;
+
+  if (!Array.isArray(configData.VENUES.MAPPING)) {
+    errors.push("VENUES.MAPPING must be an array.");
+    return;
+  }
+
+  const seenNames = new Set();
+  const locationOwner = new Map();
+
+  for (const [index, venue] of configData.VENUES.MAPPING.entries()) {
+    if (typeof venue.NAME !== "string" || venue.NAME.length === 0) {
+      errors.push(`VENUES.MAPPING[${index}] must have a non-empty NAME.`);
+    } else if (seenNames.has(venue.NAME)) {
+      errors.push(`VENUES.MAPPING contains duplicate NAME "${venue.NAME}".`);
+    } else {
+      seenNames.add(venue.NAME);
+    }
+
+    if (
+      !Array.isArray(venue.LOCATIONS) ||
+      venue.LOCATIONS.length === 0 ||
+      !venue.LOCATIONS.every((loc) => typeof loc === "string" && loc.length > 0)
+    ) {
+      errors.push(
+        `VENUES.MAPPING[${index}] must have a non-empty LOCATIONS array of strings.`
+      );
+      continue;
+    }
+
+    for (const loc of venue.LOCATIONS) {
+      const owner = locationOwner.get(loc);
+      if (owner !== undefined && owner !== venue.NAME) {
+        errors.push(
+          `Location "${loc}" is assigned to both "${owner}" and "${venue.NAME}" in VENUES.MAPPING.`
+        );
+      } else {
+        locationOwner.set(loc, venue.NAME);
+      }
     }
   }
 }


### PR DESCRIPTION
With a large convention split over multiple venues, it can be hard to navigate the list of rooms. This allows you to group locations under venue headings in the dropdown. It also shows the venue in the item labels as well.

Under each venue heading in the location dropdown, it adds an `All @venue` option, which shows items happening in any room in that venue. This is useful for people who are in a particular venue and are looking for something happening in the next slot, and know they don't particularly want to travel to the other venue.

Any room that isn't assigned a venue get grouped under "Other".

Venue groupings are optional. If they are omitted, the locations remains a flat list.

I elected to make the grouping of locations into venues a config thing rather than putting it into the schedule JSON so that the feature could be used without having to update the JSON producers.

<img width="528" height="764" alt="image" src="https://github.com/user-attachments/assets/93a76e92-0034-458a-b7cb-9125ff9e2954" />
<img width="2348" height="1078" alt="image" src="https://github.com/user-attachments/assets/7a7e1bdb-c4d8-41a9-a961-2784ce00ae12" />
