### PR TITLE
Fix location URL bugs in nav highlight and filter reset

### DIFF
--- a/src/components/FilterableProgram.jsx
+++ b/src/components/FilterableProgram.jsx
@@ -92,6 +92,9 @@ const FilterableProgram = () => {
   function resetLimitsAndFilters() {
     resetDisplayLimit();
     resetProgramFilters();
+    // Clearing the filters must also drop any /loc/ URL, otherwise a refresh
+    // restores the location filter from the path.
+    navigate("/");
   }
 
   /**
@@ -298,7 +301,6 @@ const FilterableProgram = () => {
               isSearchable={configData.LOCATIONS.SEARCHABLE}
               value={selLoc}
               onChange={(value) => {
-                console.log(value);
                 resetDisplayLimit();
                 setSelLoc(value);
                 if (value.length) {

--- a/src/components/LocationProgramme.jsx
+++ b/src/components/LocationProgramme.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useStoreActions } from "easy-peasy";
 import { useParams } from "react-router-dom";
 import FilterableProgram from "./FilterableProgram";
@@ -10,12 +11,12 @@ const LocationProgramme = () => {
   );
 
   const params = useParams();
-  const locations = params.locList.split("~").map((loc) => decodeURIComponent(loc));
-  if (locations.length) {
-    setSelLoc(locations.map((loc) => {
-      return { value: loc, label: labelForLocationValue(loc, configData) };
-    }));
-  }
+  useEffect(() => {
+    const locations = params.locList.split("~").map((loc) => decodeURIComponent(loc));
+    if (locations.length) {
+      setSelLoc(locations.map((loc) => { return {value: loc, label: labelForLocationValue(loc, configData)}; }));
+    }
+  }, [params.locList, setSelLoc]);
 
   return (
     <FilterableProgram />

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -1,4 +1,4 @@
-import { NavLink } from "react-router-dom";
+import { NavLink, useLocation } from "react-router-dom";
 import {
   FaCalendarAlt,
   FaUsers,
@@ -11,8 +11,9 @@ import NavIcon from "./NavIcon";
 import UserStatus from "./UserStatus";
 
 const Navigation = () => {
+  const { pathname } = useLocation();
   const coreLinks = [
-    { to: "/", icon: FaCalendarAlt, label: configData.NAVIGATION.PROGRAM },
+    { to: "/", icon: FaCalendarAlt, label: configData.NAVIGATION.PROGRAM, forceActive: pathname.startsWith("/loc/") },
     { to: "/people", icon: FaUsers, label: configData.NAVIGATION.PEOPLE },
     { to: "/myschedule", icon: FaStar, label: configData.NAVIGATION.MYSCHEDULE },
     ...("INFO" in configData.NAVIGATION
@@ -24,9 +25,9 @@ const Navigation = () => {
   return (
     <nav className="navigation">
       <ul>
-        {coreLinks.map(({ to, icon, label }) => (
+        {coreLinks.map(({ to, icon, label, forceActive }) => (
           <li key={to}>
-            <NavLink to={to}>
+            <NavLink to={to} className={({ isActive }) => (isActive || forceActive ? "active" : undefined)}>
               <NavIcon icon={icon} />
               {label}
             </NavLink>

--- a/src/components/Switch.jsx
+++ b/src/components/Switch.jsx
@@ -1,5 +1,5 @@
 const Switch = ({ id, label, checked, onChange }) => (
-  <div class="switch-wrapper">
+  <div className="switch-wrapper">
     <button
       className="switch"
       id={id}


### PR DESCRIPTION
- Highlight the Programme nav link on /loc/ pages, which are location-filtered views of the programme.
- Navigate back to / when clearing all filters, so refreshing no longer resurrects the location filter from the URL.
- Set the location filter from the URL in an effect rather than during render, fixing a React cross-component update error.