### PR TITLE
Improve compatibility with older browsers

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -159,6 +159,9 @@ body {
   display: grid;
   grid-template-columns: auto 1fr;
   align-content: start;
+  /* dvh isn't understood below Safari 15.4/Chrome 108/Firefox 101 - the vh
+     fallback is overridden by the line below on browsers that support dvh. */
+  min-height: 100vh;
   min-height: 100dvh;
   text-align: left;
   font-size: 1.25rem;
@@ -181,6 +184,7 @@ body {
 .sidebar {
   position: sticky;
   top: 0;
+  height: 100vh;
   height: 100dvh;
   overflow-y: auto;
   width: 16rem;
@@ -436,6 +440,10 @@ header img {
   position: fixed;
   inset: 0;
   background: var(--shadow-50);
+  /* Unprefixed backdrop-filter is Safari 18+ only; -webkit- covers back to
+     Safari 9. Below both, the scrim's solid background still shows - just
+     without the blur. */
+  -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
   display: flex;
   align-items: flex-start;
@@ -575,7 +583,11 @@ header img {
   }
 
   /* Lock background scroll while the drawer is open (the drawer itself scrolls).
-     The modal dialog inerts the background but doesn't prevent it scrolling. */
+     The modal dialog inerts the background but doesn't prevent it scrolling.
+     :has() is unsupported below Safari 15.5/Chrome 106/Firefox 122; there the
+     whole rule is invalid and dropped, so the background can scroll behind
+     the drawer. Accepted as a graceful, cosmetic-only degradation - no
+     fallback exists short of a JS-driven scroll lock. */
   body:has(dialog.sidebar-drawer[open]) {
     overflow: hidden;
   }
@@ -623,6 +635,7 @@ header img {
     position: fixed;
     inset: 0 auto 0 0;
     width: 16rem;
+    height: 100vh;
     height: 100dvh;
     box-sizing: border-box;
     box-shadow: 4px 0 16px var(--shadow-20);

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,3 +1,4 @@
+import "./polyfills";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,0 +1,14 @@
+// Object.hasOwn (ES2022) isn't available below Safari 15.4/Chrome 93/Firefox
+// 92 - react-markdown calls it directly, so without this an old browser
+// throws a TypeError the first time markdown is rendered. Polyfilled by hand
+// rather than pulling in a general polyfill library, since this is the only
+// gap: everything else the app uses is already covered by the ES2015 target.
+if (typeof Object.hasOwn !== "function") {
+  Object.defineProperty(Object, "hasOwn", {
+    value: (object, property) =>
+      Object.prototype.hasOwnProperty.call(object, property),
+    configurable: true,
+    enumerable: false,
+    writable: true,
+  });
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -71,6 +71,7 @@ export default defineConfig({
     open: true,
   },
   build: {
+    target: "es2015",
     outDir: "build",
     minify: "terser",
     terserOptions: {


### PR DESCRIPTION
Target es2015 for the build output to maintain compatibility with old browsers.

`Object.hasOwn` increased the baseline browser required. It's not clear how many people this would actually have impacted in practice, but out of caution we're adding in a polyfill until we have enough data to know if we can remove it.

This also adds some CSS fallbacks for old browsers, so they should hopefully render a little better.