### PR TITLE
Add link icons for newer social platforms.

### DIFF
--- a/docs/conclar_file_specs.md
+++ b/docs/conclar_file_specs.md
@@ -146,9 +146,9 @@ For KonOpas compatibility, each array may optionally be wrapped as `var program 
 		],
 		"desc": "",
 		"links": {
-			"signup": "http://url.to.signup/",
-			"meeting": "http://url.to.meeting/",
-			"recording": "http://url.to.recording/"
+			"signup": "http:\/\/url.to.signup\/",
+			"meeting": "http:\/\/url.to.meeting\/",
+			"recording": "http:\/\/url.to.recording\/"
 		}
 	},
 	...
@@ -200,7 +200,7 @@ Note: these fields are not mutually exclusive between conventions, and it is pos
 			"img_256_url": "\/images\/galahad.jpg",
 			"url": "http:\/\/en.wikipedia.org\/wiki\/Galahad"
 		},
-		"bio": "Sir Galahad (/ˈɡæləhæd/; Middle Welsh: Gwalchavad, sometimes referred to as Galeas /ɡəˈliːəs/ or Galath /ˈɡæləθ/), in Arthurian legend, is a knight of King Arthur's Round Table and one of the three achievers of the Holy Grail."
+		"bio": "Sir Galahad (\/ˈɡæləhæd\/; Middle Welsh: Gwalchavad, sometimes referred to as Galeas \/ɡəˈliːəs\/ or Galath \/ˈɡæləθ\/), in Arthurian legend, is a knight of King Arthur's Round Table and one of the three achievers of the Holy Grail."
 	},
 	{
 		"id": "bf871858-39d4-4eeb-9f5f-611112262a9c",
@@ -228,7 +228,7 @@ Note: these fields are not mutually exclusive between conventions, and it is pos
 * `links` is an array of items for the person. Currently implemented links are:
     * `img` - a link which is a path to a thumbnail image of the person;
     * `photo` - a link which is a path to a thumbnail image of the person;
-    * Other links will be displayed as icons under bio. Known link types are: `bsky`, `bluesky`, `fb`, `facebook`, `instagram`, `linkedin`, `mast`, `mdon`, `mastodon`, `threads`, `tumblr`, `twitch`, `tiktok`, `twitter`, `website`, `yt`, `youtube`, and will be shown with a suitable icon. A generic link icon will be used for other link types.
+    * Other links will be displayed as icons under bio. Known link types are: `bsky`, `bluesky`, `fb`, `facebook`, `fediverse`, `instagram`, `linkedin`, `mast`, `mdon`, `mastodon`, `threads`, `tumblr`, `twitch`, `tiktok`, `twitter`, `website`, `yt`, `youtube`, and will be shown with a suitable icon. A generic link icon will be used for other link types.
 * `img_256_url` - a link which is a path to a thumbnail image of the person (used by Grenadine). Note this is in the root level of the `people` record, not under `links`.
 * `bio` is the biography of the person.
     * Note: The fields `desc` for program.js and `bio` for people.js can support HTML tags, which get sanitized for dangerous HTML, but all other fields must be plain text.

--- a/docs/conclar_file_specs.md
+++ b/docs/conclar_file_specs.md
@@ -195,10 +195,10 @@ Note: these fields are not mutually exclusive between conventions, and it is pos
 		"tags": [ {"value": "G1", "label": "GoH"} ],
 		"prog": [ "416" ],
 		"links": {
-			"img": "/images/galahad.jpg",
-			"photo": "/images/galahad.jpg",
-			"img_256_url": "/images/galahad.jpg",
-			"url": "http://en.wikipedia.org/wiki/Galahad"
+			"img": "\/images\/galahad.jpg",
+			"photo": "\/images\/galahad.jpg",
+			"img_256_url": "\/images\/galahad.jpg",
+			"url": "http:\/\/en.wikipedia.org\/wiki\/Galahad"
 		},
 		"bio": "Sir Galahad (/ˈɡæləhæd/; Middle Welsh: Gwalchavad, sometimes referred to as Galeas /ɡəˈliːəs/ or Galath /ˈɡæləθ/), in Arthurian legend, is a knight of King Arthur's Round Table and one of the three achievers of the Holy Grail."
 	},
@@ -209,8 +209,9 @@ Note: these fields are not mutually exclusive between conventions, and it is pos
 		"tags": [ {"value": "v1", "label": "Virtual" } ],
 		"prog": [ "1234", "416", "810" ],
 		"links": {
-			"twitter": "justsomeguy9999",
-			"url": "http://example.com/just-someguys-blog"
+			"bsky": "https:\/\/bsky.app\/profile\/justsomeguy9999.bsky.social",
+			"twitter": "https\/\/twitter.com\/justsomeguy9999",
+			"website": "http:\/\/example.com\/just-someguys-blog"
 		},
 		"bio": "He was voted \"Worst Dressed Sentient Being in the Known Universe\" seven consecutive times. He's been described as \"the best Bang since the Big One\" by Eccentrica Gallumbits, and as \"one hoopy frood\" by others. In the seventh episode of the original radio series, the narrator describes Beeblebrox as being the \"owner of the hippest place in the universe\" (his own left cranium), as voted on in a poll of the readers of the fictional magazine Playbeing."
 	},
@@ -227,7 +228,7 @@ Note: these fields are not mutually exclusive between conventions, and it is pos
 * `links` is an array of items for the person. Currently implemented links are:
     * `img` - a link which is a path to a thumbnail image of the person;
     * `photo` - a link which is a path to a thumbnail image of the person;
-    * Other links will be displayed as icons under bio. Known link types are: `twitter`, `fb`, `facebook`, `instagram`, `twitch`, `youtube`, `tiktok`, `linkedin`, `website`, and will be shown with a suitable icon. A generic link icon will be used for other link types.
+    * Other links will be displayed as icons under bio. Known link types are: `bsky`, `bluesky`, `fb`, `facebook`, `instagram`, `linkedin`, `mast`, `mdon`, `mastodon`, `threads`, `tumblr`, `twitch`, `tiktok`, `twitter`, `website`, `yt`, `youtube`, and will be shown with a suitable icon. A generic link icon will be used for other link types.
 * `img_256_url` - a link which is a path to a thumbnail image of the person (used by Grenadine). Note this is in the root level of the `people` record, not under `links`.
 * `bio` is the biography of the person.
     * Note: The fields `desc` for program.js and `bio` for people.js can support HTML tags, which get sanitized for dangerous HTML, but all other fields must be plain text.

--- a/public/2022/people.json
+++ b/public/2022/people.json
@@ -11,7 +11,12 @@
       "prog": ["17", "101"],
       "bio": "<p>James has been involved in fandom and conventions since the early 1990s. He has helped organise many conventions in Ireland and abroad, including&nbsp;<a href=\"http:\/\/www.octocon.com\/\">Octocon<\/a>, P-Con, Shamrokon (Eurocon), Eastercons and Worldcons. He has been involved in fanzines, fan clubs and fan funds, and is a massive space nerd with a particular fascination about zero gravity toilets. A huge fan of LEGO, James will attempt to include it in convention programmes at every opportunity.<\/p>",
       "links": {
-        "img": "https:\/\/planz.octocon.com\/participant_photos\/pp801c14f07f9724229175b8ef8b4585a8.jpg"
+        "img": "https:\/\/planz.octocon.com\/participant_photos\/pp801c14f07f9724229175b8ef8b4585a8.jpg",
+        "fb": "https:\/\/www.facebook.com\/lostcarpark",
+        "bsky": "https:\/\/bsky.app\/profile\/lostcarpark.bsky.social",
+        "mast": "https:\/\/mastodon.ie\/@lostcarpark",
+        "linkedin": "https:\/\/www.linkedin.com\/in\/lostcarpark",
+        "website": "https:\/\/lostcarpark.com"
       }
     },
     {

--- a/src/components/PersonLinks.jsx
+++ b/src/components/PersonLinks.jsx
@@ -1,14 +1,20 @@
 import React from "react";
 import {
-  FaTwitter,
   FaFacebook,
-  FaLinkedin,
-  FaInstagram,
-  FaTiktok,
-  FaTwitch,
-  FaYoutube,
   FaGlobe,
+  FaInstagram,
+  FaLinkedin,
+  FaMastodon,
+  FaTiktok,
+  FaTumblr,
+  FaTwitch,
+  FaTwitter,
+  FaYoutube,
 } from "react-icons/fa";
+import {
+  FaBluesky,
+  FaThreads
+} from "react-icons/fa6";
 import {
   IoLink,
 } from "react-icons/io5";
@@ -18,28 +24,40 @@ const PersonLinks = ({ person }) => {
   const regex = /^(?:http(s)?:\/\/)[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=.]+$/;
   /**
    * Take a link type and return an appropriate Icon.
-   * @param {string} type 
+   * @param {string} type
    * @returns {string}
    */
   const getLinkIcon = (type) => {
     switch (type) {
-      case "twitter":
-        return <FaTwitter />;
+      case "bsky":
+      case "bluesky":
+        return <FaBluesky />;
       case "fb":
       case "facebook":
         return <FaFacebook />;
       case "instagram":
         return <FaInstagram />;
-      case "twitch":
-        return <FaTwitch />;
-      case "youtube":
-        return <FaYoutube />;
-      case "tiktok":
-        return <FaTiktok />;
       case "linkedin":
         return <FaLinkedin />;
+      case "mdon":
+      case "mast":
+      case "mastodon":
+        return <FaMastodon />;
+      case "tiktok":
+        return <FaTiktok />;
+      case "threads":
+        return <FaThreads />
+      case "tumblr":
+        return <FaTumblr />
+      case "twitch":
+        return <FaTwitch />;
+      case "twitter":
+        return <FaTwitter />;
       case "website":
         return <FaGlobe />;
+      case "youtube":
+      case "yt":
+        return <FaYoutube />;
       default:
         return <IoLink />;
     }

--- a/src/components/PersonLinks.jsx
+++ b/src/components/PersonLinks.jsx
@@ -18,7 +18,9 @@ import {
 import {
   IoLink,
 } from "react-icons/io5";
-
+import {
+  PiFediverseLogo
+} from "react-icons/pi";
 
 const PersonLinks = ({ person }) => {
   const regex = /^(?:http(s)?:\/\/)[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=.]+$/;
@@ -35,6 +37,8 @@ const PersonLinks = ({ person }) => {
       case "fb":
       case "facebook":
         return <FaFacebook />;
+      case "fediverse":
+        return <PiFediverseLogo />;
       case "instagram":
         return <FaInstagram />;
       case "linkedin":
@@ -42,6 +46,7 @@ const PersonLinks = ({ person }) => {
       case "mdon":
       case "mast":
       case "mastodon":
+      case "fediverse":
         return <FaMastodon />;
       case "tiktok":
         return <FaTiktok />;


### PR DESCRIPTION
Resolves #210.

Newer social media platforms will just receive a generic 🔗 icon.

Bluesky seems particularly popular these days, so would be nice to have proper link icons for them.

I've added Bluesky, Mastodon, Tumblr, and Threads.

Note that this does require platforms generating the programme to support the appropriate link codes. It might be worth looking at matching the URL pattern to assign icons automatically.