### PR TITLE
Add QR code to person page.

### DIFF
--- a/docs/config_reference.md
+++ b/docs/config_reference.md
@@ -156,7 +156,7 @@ Copy `src/config_example.json` to `src/config.json` and customise. See the [Gett
 - `SHOW_PAST_ITEMS.CHECKBOX_LABEL` (string) — Label for the show-past-items checkbox.
 - `SHOW_PAST_ITEMS.ADJUST_MINUTES` (number) — Some wiggle room (in minutes) in order not to hide past items immediately as they start.
 - `SHOW_PAST_ITEMS.FROM_START` (boolean) — If true, adjust from the item's start time rather than its end time when deciding whether it's "past".
-- `PEOPLE` (object) — Settings for the people list and individual participant pages.
+- `PEOPLE` (object, required) — Settings for the people list and individual participant pages.
 - `PEOPLE.MODERATORS` (object)
 - `PEOPLE.MODERATORS.MODERATOR_LABEL` (string) — Label appended to a participant's name when they are the moderator of an item.
 - `PEOPLE.THUMBNAILS` (object)
@@ -183,6 +183,10 @@ Copy `src/config_example.json` to `src/config.json` and customise. See the [Gett
 - `PEOPLE.BIO` (object)
 - `PEOPLE.BIO.PURIFY_OPTIONS` (object) — Additional options passed to DOMPurify when processing participant bios. For more details, see ITEM_DESCRIPTION.PURIFY_OPTIONS.
 - `PEOPLE.BIO.PURIFY_OPTIONS.FORBID_ATTR` (array of string)
+- `PEOPLE.SHARE` (object, required)
+- `PEOPLE.SHARE.LABEL` (string, required) — Heading for sharing person.
+- `PEOPLE.SHARE.DESCRIPTION` (string, required) — Descriptive message for sharing person.
+- `PEOPLE.SHARE.LINK_LABEL` (string, required) — Label for sharing person link.
 - `USELESS_CHECKBOX` (object)
 - `USELESS_CHECKBOX.CHECKBOX_LABEL` (string) — Label for any "useless" placeholder checkboxes used for layout alignment.
 - `INFORMATION` (object, required)

--- a/src/components/Person.jsx
+++ b/src/components/Person.jsx
@@ -6,6 +6,7 @@ import DOMPurify from "dompurify";
 import { MdOutlineArrowBackIos } from "react-icons/md";
 import PersonLinks from "./PersonLinks";
 import ProgramList from "./ProgramList";
+import SharePerson from "./SharePerson";
 import Tag from "./Tag";
 import configData from "../config.json";
 
@@ -62,6 +63,7 @@ const Person = () => {
       />
       <PersonLinks person={person} />
       <ProgramList program={filteredProgram} />
+      <SharePerson person={person} />
     </div>
   );
 };

--- a/src/components/SharePerson.jsx
+++ b/src/components/SharePerson.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import QRCode from "react-qr-code";
+import configData from "../config.json";
+
+const SharePerson = ({ person }) => {
+  const link = window.publicUrl + "people/" + person.id;
+  const absLink = `${window.location.origin}${link}`;
+
+  return (
+    <div className="share-group">
+      <div className="share-head">{configData.PEOPLE.SHARE.LABEL}</div>
+      <div className="share-panel">
+        {configData.PEOPLE.SHARE.DESCRIPTION}
+        <div className="share-link">
+          <Link to={link}>{configData.PEOPLE.SHARE.LINK_LABEL}</Link>
+        </div>
+      </div>
+      <div className="share-qr-code">
+        <QRCode value={absLink} level="L" />
+      </div>
+    </div>
+  );
+};
+
+export default SharePerson;

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -13,6 +13,7 @@
     "NAVIGATION",
     "HEADER",
     "PROGRAM",
+    "PEOPLE",
     "SETTINGS",
     "FOOTER",
     "APPLICATION",
@@ -548,6 +549,7 @@
       "type": "object",
       "additionalProperties": false,
       "description": "Settings for the people list and individual participant pages.",
+      "required": ["SHARE"],
       "properties": {
         "MODERATORS": {
           "type": "object",
@@ -619,6 +621,16 @@
                 "FORBID_ATTR": { "type": "array", "items": { "type": "string" } }
               }
             }
+          }
+        },
+        "SHARE": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["LABEL", "DESCRIPTION", "LINK_LABEL"],
+          "properties": {
+            "LABEL": { "type": "string", "description": "Heading for sharing person." },
+            "DESCRIPTION": { "type": "string", "description": "Descriptive message for sharing person." },
+            "LINK_LABEL": { "type": "string", "description": "Label for sharing person link." }
           }
         }
       }

--- a/src/config_example.json
+++ b/src/config_example.json
@@ -233,6 +233,11 @@
       "PURIFY_OPTIONS": {
         "FORBID_ATTR": ["style"]
       }
+    },
+    "SHARE": {
+      "LABEL": "Share person",
+      "DESCRIPTION": "Copy and paste this link to share this person. Or point your camera at the QR code below.",
+      "LINK_LABEL": "Shareable link"
     }
   },
   "USELESS_CHECKBOX": {


### PR DESCRIPTION
This adds a new "Share person" section to the bottom of the "Person" page, with a link and QR code to share that person (and show their program).

Note that the QR code encodes the URL to the person's Person page, it does not share the individual schedule items the way the "My Schedule" QR code does. Personally, I think this is preferable, as it does not try to add the items to the schedule of the person who scans the QR code.

<img width="1106" height="617" alt="image" src="https://github.com/user-attachments/assets/b5cdf267-5509-4f01-900a-2b2d60cf7c4b" />
