### PR TITLE
Add schema validation of configuration

### DIFF
--- a/.github/workflows/config-validation.yml
+++ b/.github/workflows/config-validation.yml
@@ -1,0 +1,43 @@
+name: Config schema validation
+
+on:
+  pull_request:
+    paths:
+      - "src/config_example.json"
+      - "src/configSchema.json"
+      - "src/validateConfig.js"
+      - "scripts/**"
+      - "docs/config_reference.md"
+      - "package.json"
+      - "package-lock.json"
+
+jobs:
+  validate-config:
+    name: Validate config_example.json against schema
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run validate:config-example
+
+  check-docs:
+    name: Check config docs are up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run docs:check

--- a/README.md
+++ b/README.md
@@ -63,167 +63,13 @@ See the [Vite deployment documentation](https://vite.dev/guide/static-deploy.htm
 
 ## Customisation
 
-The main place customisations go is the `src/config.json` file. Settings currently available include:
-
-- `APP_ID`: A unique id to distinguish between instances of multi-year conventions.
-- `APP_TITLE`: The title to appear at the top of the webpage, and in the browser window title.
-- `PROGRAM_DATA_URL` / `PEOPLE_DATA_URL`: Legacy config for the addresses of the files containing programme and people data, in the bare-array format. If these are the same, both will be read from one file, but programme data must come before people data. Mutually exclusive with `DATA_URLS`.
-- `DATA_URLS`: The address(es) of the schedule/people data files, in the self-describing `schemaVersion` object format. Specify `{ "COMBINED": "..." }` for both from one file, or `{ "SCHEDULE": "...", "PEOPLE": "..." }` for separate files — specifying both `COMBINED` and `SCHEDULE`/`PEOPLE` together, or only one of `SCHEDULE`/`PEOPLE`, is a config error. Mutually exclusive with `PROGRAM_DATA_URL`/`PEOPLE_DATA_URL`. See [docs/conclar_file_specs.md](docs/conclar_file_specs.md) for the fetched file format.
-- `FETCH_OPTIONS`: A JSON object containing options to pass when fetching data. See JavaScript [fetch()](https://developer.mozilla.org/en-US/docs/Web/API/fetch) documentation for available valies. Typical examples:
-  - `"cache": "reload"` - Should always be used so beck end program updates will be read.
-  - `"credentials": "omit"` - Use if source is not using a certificate from a recognised authority, e.g. a self signed cert.
-  - `"headers": { "Origin": "http://example.com" }` - Headers sent in the fetch. Origin may be required for Cross Origin Resource Sharing (CORS).
-- `TIMEZONE`: The name of the timezone where your convention takes place. Viewers outside convention timezone will see times in convention time, and their local time below it.
-- `TIMEZONE_CODE`: The short code for the convention timezone. Set to blank to get browser code for timezone (not recommended, as it may not select the most elegant short code).
-- `INTERACTIVE`: Set to `false` to get a non-interactive, expanded view of the schedule. The info page is also included, but not the participant list, individual participant pages, or individual item pages (regardless of the `PERMALINK.SHOW_PERMALINK` setting).
-- `HEADER`: Add an optional image to the header of the pages.
-- `HEADER.IMG_SRC`: Set to the image filename to display. May be a file in the public directory. Leave blank for no image.
-- `HEADER.IMG_ALT_TEXT`: Set to the alt text that should display for the image.
-- `HEADER.LINEFEED_AFTER_URL`: If true, place a line feed after the image.
-- `NAVIGATION`: Each value in this section sets the label that will appear on main navigation of the site. Useful for switching between different international spellings of "programme".
-- `NAVIGATION.PROGRAM`: Label for program/programme menu.
-- `NAVIGATION.PEOPLE`: Label for people menu.
-- `NAVIGATION.MYSCHEDULE`: Label for user's personal schedule.
-- `NAVIGATION.INFO`: Label for the Information menu link._
-- `NAVIGATION.EXTRA`: An array of extra menu links. Each entry should take the form: `{ "LABEL": "Octocon Home", "URL": "https://octocon.com" }`. To have no extra links, set to `"EXTRA": []` or delete `EXTRA` entry altogether. Each entry may optionally include an icon, shown before the label:
-  - `ICON_NAME`: Name of a built-in icon, e.g. `{ "LABEL": "Octocon Home", "URL": "https://octocon.com", "ICON_NAME": "Home" }`. Available names: `Discord`, `Envelope`, `Facebook`, `Globe`, `Home`, `Instagram`, `Map`, `Mastodon`, `PaperPlane`, `Question`, `Sign`, `Ticket`, `Twitter`, `Youtube`. (To add more, see `iconsByName` in `src/components/NavIcon.js`.)
-  - `ICON_URL`: URL of an image to use as the icon instead, e.g. `{ "LABEL": "Octocon Home", "URL": "https://octocon.com", "ICON_URL": "https://octocon.com/favicon.png" }`. Use this for an icon that isn't in the built-in set. If both are given, `ICON_NAME` takes precedence.
-- `HELP_TEXT.WELCOME`: Text to display to new visitors who haven't selected any programme items.
-- `HELP_TEXT.SHARING`: Text to display when user has selected items, informing them of sharing options.
-- `HELP_TEXT.CLOSE_ARIA_LABEL`: Label to describe dismiss button.
-- `LOCATIONS.SEARCHABLE`: Whether the location list can be searched by typing. (Searching can be inconvenient on touch screens.)
-- `LOCATIONS.LABEL`: Label to show on map links.
-- `LOCATIONS.MAPPING`: Array of locations, with links to show on map. Each room should be specified as: `{ "KEY": "Room name", "MAP_URL": "link to map" }`.
-- `VENUES`: Groups locations by venue, for conventions spanning more than one building. If omitted, the locations drop-down is a flat, ungrouped list.
-  - `VENUES.ALL_LABEL`: Label template for the "select this whole venue" option shown at the top of each venue's group in the locations drop-down. `@venue` is replaced with the venue name. Defaults to `"All @venue"`.
-  - `VENUES.UNGROUPED_LABEL`: Label for the group heading shown above locations that aren't listed under any venue. Defaults to `"Other"`.
-  - `VENUES.MAPPING`: Array of venues, each specified as: `{ "NAME": "Venue name", "LOCATIONS": ["Room name", "Another room"] }`. Venues are listed in the locations drop-down in the order given here. A location may only belong to one venue; locations not listed under any venue are shown grouped under `VENUES.UNGROUPED_LABEL`, below the venue groups. Selecting a venue's "All <venue>" option shows every programme item in any of that venue's locations.
-- `APPLICATION.LOADING.MESSAGE`: Message to display while loading.
-- `PROGRAM.LIMIT.SHOW`: If true, "limit number of items" drop-down will be displayed.
-- `PROGRAM.LIMIT.LABEL`: Label for limit drop-down.
-- `PROGRAM.LIMIT.OPTIONS`: Options for limit drop-down - should be an array of integers.
-- `PROGRAM.LIMIT.ALL_LABEL`: Label to show for "All" entry.
-- `PROGRAM.LIMIT.DEFAULT`: Default for limit drop-down.
-- `PROGRAM.LIMIT.SHOW_MORE.LABEL`: Label for the "Show more" button.
-- `PROGRAM.LIMIT.SHOW_MORE.NO_MORE`: Message to display when no more items available.
-- `PROGRAM.LIMIT.SHOW_MORE.NUM_EXTRA`: Number of items to add when "Show more" pressed.
-- `PROGRAM.MY_SCHEDULE.TITLE`: Title of My Schedule page.
-- `PROGRAM.MY_SCHEDULE.EMPTY.TEXT`: Text to display on My Schedule when no programme items selected.
-- `PROGRAM.MY_SCHEDULE.INTRO`: Introduction text for My Schedule page.
-- `PROGRAM.MY_SCHEDULE.SEARCH.SEARCH_LABEL`: Label for search box.
-- `PROGRAM.MY_SCHEDULE.SHARE.LABEL`: Heading for shared link section on MySchedule.
-- `PROGRAM.MY_SCHEDULE.SHARE.DESCRIPTION`: Descriptive message for link sharing section.
-- `PROGRAM.MY_SCHEDULE.SHARE.LINK_LABEL`: Label for link when single sharing link on page.
-- `PROGRAM.MY_SCHEDULE.SHARE.MAX_LENGTH`: Maximum number of characters in each link.
-- `PROGRAM.MY_SCHEDULE.SHARE.MULTIPLE_DESCRIPTION`: Description to display when multiple links displayed.
-- `PROGRAM.MY_SCHEDULE.SHARE.MULTIPLE_LINK_LABEL`: Label for link when multiple links shown. @number replaced by number of link.
-- `PROGRAM.SHARED.TITLE`: Title of Shared Programme Items page.
-- `PROGRAM.SHARED.DESCRIPTION`: Descriptive text for page showing shared links.
-- `PROGRAM.SHARED.BUTTON_LABEL`: Text for label of "Add all to My Schedule" button.
-- `TAGS.PLACEHOLDER`: The placeholder when selecting tags (unless separated).
-- `TAGS.SEARCHABLE`: Whether the tag list can be searched by typing (unless separated).
-- `TAGS.HIDE`: If true, hide the tags drop-down. Tags still displayed on items.
-- `TAGS.SEPARATE`: An array of tag prefixes to separate into individual drop-downs, and if drop-down is searchable or hidden. Tags should be specified as follows: `{ "PREFIX": "type", "PLACEHOLDER": "Select type", "SEARCHABLE": true|false, "HIDE": true|false }`.
-- `TAGS.FORMAT_AS_TAG`: If set to true, turns Grenadine item format into a KonOpas-style "type" tag.
-- `TAGS.DAY_TAG.GENERATE`: If set to true, will generate tags for each day of the convention.
-- `TAGS.DAY_TAG.DAYS`: Object with key values pairs for day names. Keys are day numbers from 1 (Monday) to 7 (Sunday).
-- `TAGS.DAY_TAG.PLACEHOLDER`: The placeholder for the "day" tags drop down.
-- `TAGS.DAY_TAG.SEARCHABLE`: Whether day tag list can be searched by typing.
-- `TAGS.DAY_TAG.HIDE`: If true, hide day tags drop-down. Day tags still shown on items if GENERATE true.
-- `TAGS.DONTLIST`: An array of tags not to list in the drop-downs and programme item tag lists.
-- `HIDE_BEFORE.HIDE`: If true hide "hide before" dropdown. If false, show dropdown containing times to hide items before.
-- `HIDE_BEFORE.PLACEHOLDER`: Placeholder text for hide before drop-down.
-- `HIDE_BEFORE.TIMES`: Array of times to list in hide before drop-down. Each entry should be specified as follows: { "TIME": "time in hh:mm:ss format", "LABEL_24H": "24 hour label", "LABEL_12H": "12 hour label" }. Time should be in convention timezone.
-- `FILTER.RESET.LABEL`: The label for the "Reset filters" button.
-- `PERMALINK.SHOW_PERMALINK`: If true, display a "permalink" icon when each program item is expanded.
-- `PERMALINK.PERMALINK_TITLE`: "Title" text displayed when mouse is hovered over permalink icon.
-- `CALENDARLINK.SHOW`: If true, display a calendar download icon when each program item is expanded.
-- `CALENDARLINK.CALENDARLINK`: "Title" text displayed when mouse is hovered over calendar download icon.
-- `EXPAND.EXPAND_ALL_LABEL`: Label text for Expand All button.
-- `EXPAND.COLLAPSE_ALL_LABEL`: Label for Collapse All button.
-- `EXPAND.SPRING_CONFIG`: Config to apply to the configuration of the 'spring' when expanding items. This may be a simply duration, such as `{ "duration": 100 }` to expand in 100ms, or can configure more dynamic spring effects, such as `{ mass: 1, tension: 1000, friction: 30 }`. Full list of options in [react-spring documentation](https://react-spring.io/common/configs).
-- `ITEM_DESCRIPTION.PURIFY_OPTIONS`: Pass additional options to DOMPurify when processing item descriptions. For the available options, see [the DOMPurify documentation](https://github.com/cure53/DOMPurify#can-i-configure-dompurify). Format options as JSON, _e.g._, `{"FORBID_ATTR": ["style"]}`.
-- `LINKS`: An array of link types expected in the program data.  Individual entries should take the form `{"NAME": "signup", "TEXT": "Click to sign up", "TAG": "", "WHEN": ["before"]}`.
-  - `NAME` should be the name of the link as it appears in the links object in the program data.
-  - `TEXT` is the text that should appear on this link in ConClár.
-  - `TAG` is an optional tag to add to every program item which includes a matching link.  If using prefixed tags, include the prefix, *e.g.*, `"type:Workshop"`.
-  - `WHEN` is an optional array listing times when the link will be visible. Valid entries are `"before"`, `"during"`, and `"after"`. For example, a link type that specifies `"WHEN": ["during"]` will only be visible when the programme item is taking place. Multiple options may be specified, such as `"WHEN": ["before", "during"]`, which will cause the link to be visible prior to the item and while it is happening, but will disappear when it finishes.
-- `LOCAL_TIME.CHECKBOX_LABEL`: Label for the "Show Local Time" checkbox.
-- `LOCAL_TIME.NOTICE`: Label for notie telling users how local time displayed.
-- `LOCAL_TIME.PREV_DAY`: Label appended to local time if local time is before start of advertised day.
-- `LOCAL_TIME.NEXT_DAY`: Label appended to local time if local time is after end of advertised day.
-- `LOCAL_TIME.FAILURE`: Local time depends on string conversions, and could fail in some circumstances. Display this message if unable to convert.
-- `TIME_FORMAT.DEFAULT_12HR`: Set to true if you want time displayed in 12 hour format by default.
-- `TIME_FORMAT.SHOW_CHECKBOX`: If set to false, users will not be given option to change between 12 and 24 hour time.
-- `TIME_FORMAT.CHECKBOX_LABEL`: Label for the 12 hour time checkbox label.
-- `TIME_FORMAT.AM`: Label for AM times.
-- `TIME_FORMAT.PM`: Label for PM times.
-- `DURATION.SHOW_DURATION`: If true, `mins` from program data will be displayed.
-- `DURATION.DURATION_LABEL`: Format for duration. `@mins` will be replaced by number of minutes. Note: do not translate `@mins`.
-- `START_TIME.START_TIME_LABEL`: Format for start time with just con time, when read by screen readers. `@con_time` will be replaced by the start time. Note: do not translate `@con_time`.
-- `START_TIME.START_TIME_WITH_LOCAL_LABEL`: Format for start time with both con and local time, when read by screen readers. `@con_time` and `@local_time` will be replaced by the start time. Note: do not translate `@con_time` or `@local_time`.
-- `SHOW_PAST_ITEMS.SHOW_CHECKBOX`: Set to true to show the option during the convention; otherwise past programme items are shown by default.
-- `SHOW_PAST_ITEMS.CHECKBOX_LABEL`: Label for the show past items checkbox.
-- `SHOW_PAST_ITEMS.ADJUST_MINUTES`: Some wiggle room (in minutes) in order not to hide past items immediately as they start.
-- `PEOPLE.THUMBNAILS.SHOW_THUMBNAILS`: Set to false to not show member thumbnails (useful to remove spurious controls if pictures not in file).
-- `PEOPLE.THUMBNAILS.SHOW_CHECKBOX`: Set to false to hide "Show thumbnails" checkbox.
-- `PEOPLE.THUMBNAILS.CHECKBOX_LABEL`: Label for "Show thumbnails" checkbox.
-- `PEOPLE.THUMBNAILS.DEFAULT_IMAGE`: Set to default thumbnail for participants with no photo. Can be filename of image in public directory, or external URL. Leave blank for no default thumbnail.
-- `PEOPLE.SORT.SHOW_CHECKBOX`: Set to false to hide "Sort by full name" checkbox. Useful if your data only contains "name for publications".
-- `PEOPLE.SORT.CHECKBOX_LABEL`: Label for "Sort by full name" checkbox.
-- `PEOPLE.TAGS.PLACEHOLDER`: The placeholder when selecting person tags (unless separated).
-- `PEOPLE.TAGS.SEARCHABLE`: Whether the tag list can be searched by typing (unless separated).
-- `PEOPLE.TAGS.HIDE`: If true, hide the tags drop-down. Tags still displayed on items.
-- `PEOPLE.TAGS.SEPARATE`: An array of tag prefixes to separate into individual drop-downs, and if drop-down is searchable or hidden. Tags should be specified as follows: `{ "PREFIX": "type", "PLACEHOLDER": "Select type", "SEARCHABLE": true|false, "HIDE": true|false }`.
-- `PEOPLE.SEARCH.SHOW_SEARCH`: Set to false to hide "people" search box.
-- `PEOPLE.SEARCH.SEARCH_LABEL`: Label for "people2 search box.
-- `PEOPLE.BIO.PURIFY_OPTIONS`: Pass additional options to DOMPurify when processing participant bios. For more details, see `ITEM_DESCRIPTION.PURIFY_OPTIONS` above.
-- `USELESS_CHECKBOX.CHECKBOX_LABEL`: Label for any useless checkboxes.
-- `SETTINGS.TITLE.LABEL`: Label for settings page.
-- `SETTINGS.TIME_FORMAT.LABEL`: Label for time format group.
-- `SETTINGS.TIME_FORMAT.T12_HOUR_LABEL`: Label for 12 hour option.
-- `SETTINGS.TIME_FORMAT.T24_HOUR_LABEL`: Label for 24 hour option.
-- `SETTINGS.SHOW_LOCAL_TIME.LABEL`: Label for Show Local Time option group.
-- `SETTINGS.SHOW_LOCAL_TIME.NEVER_LABEL`: Label for "Never show" option.
-- `SETTINGS.SHOW_LOCAL_TIME.DIFFERS_LABEL`: Label for "Display if different from Convention timezone".
-- `SETTINGS.SHOW_LOCAL_TIME.ALWAYS_LABEL`: Label for "Always display" option.
-- `SETTINGS.SHOW_TIMEZONE.LABEL`: Label for Show timezone after times option group.
-- `SETTINGS.SHOW_TIMEZONE.NEVER_LABEL`: Label for "Never show" option.
-- `SETTINGS.SHOW_TIMEZONE.IF_LOCAL_LABEL`: Label for "Show timezone if local time shown".
-- `SETTINGS.SHOW_TIMEZONE.ALWAYS_LABEL`: Label for "Always show" option.
-- `SETTINGS.SELECT_TIMEZONE.LABEL`: Label for select timezone group,
-- `SETTINGS.SELECT_TIMEZONE.BROWSER_DEFAULT_LABEL`: Label to use browser default timezone (will have name of timezone appended).
-- `SETTINGS.SELECT_TIMEZONE.SELECT_LABEL`: Label to select explicit timezone.
-- `SETTINGS.DARK_MODE.LABEL`: Label for dark mode settings group.
-- `SETTINGS.DARK_MODE.BROWSER_DEFAULT_LABEL`: Label for default browser dark mode preference.
-- `SETTINGS.DARK_MODE.BROWSER_LIGHT_LABEL`: Label to indicate browser is currently in light mode.
-- `SETTINGS.DARK_MODE.BROWSER_DARK_LABEL`: Label to indicate browser is currently in dark mode.
-- `SETTINGS.DARK_MODE.LIGHT_MODE_LABEL`: Label for forcing light mode.
-- `SETTINGS.DARK_MODE.DARK_MODE_LABEL`: Label for forcing dark mode.
-- `INFORMATION.MARKDOWN_URL`: The address of the markdown file containing additional information about the convention.
-- `INFORMATION.LOADING_MESSAGE`: Text to show while Markdown file is loading (usually never seen).
-- `FOOTER.SITE_NOTE_MARKDOWN`: General note displayed in the footer of the page. May use Markdown for encoding of links, emphesis, etc.
-- `FOOTER.COPYRIGHT_MARKDOWN`: Copyright notice if required. May include Markdown.
-- `FOOTER.CONCLAR_NOTE_MARKDOWN`: Note crediting ConClár. You are free to remove or modify this, but we politely request retaining to help promote this free tool.
-- `TIMER.FETCH_INTERVAL_MINS`: Number of minutes between refreshes of program data.
-- `TIMER.TIMER_TICK_SECS`: Number of seconds between checks of timer.
-- `DEBUG_MODE.ENABLE`: If true, display banner showing online status, and allowing manual data fetch.
-- `DEBUG_MODE.ONLINE_LABEL`: Label to display in debug mode when online.
-- `DEBUG_MODE.OFFLINE_LABEL`: Label to display in debug mode when offline.
-- `DEBUG_MODE.FETCH_BUTTON_LABEL`: Label to display in debug mode on Fetch button.
-- `SYNC.API_URL`: The base URL of your sync server API (e.g. `https://auth.example-con.org/api`). If omitted or empty, sync is disabled entirely.
-- `SYNC.LOADING_LABEL`: Label shown while the profile is being fetched on startup.
-- `SYNC.LOGIN_LABEL`: Label for the login link when the user is not authenticated.
-- `SYNC.LOGOUT_LABEL`: Label for the logout link. `@display_name` is replaced with the user's display name.
-- `SYNC.ERROR_LABEL`: Label for the error message when unable to connect to sync server.
-- `SYNC.WARNING.HEADING`: Heading of the popup shown the first time an unauthenticated user adds or removes a selection.
-- `SYNC.WARNING.TITLE`: Main message body of the sync warning popup.
-- `SYNC.WARNING.DETAILS`: Expandable detail text shown when the user clicks "More information" in the sync warning popup.
-- `SYNC.WARNING.DETAILS_LABEL`: Label for the button that expands the detail text in the sync warning popup.
-- `SYNC.WARNING.LOGIN_LABEL`: Label for the primary login button in the sync warning popup.
-- `SYNC.WARNING.DISMISS_LABEL`: Label for the dismiss link in the sync warning popup.
-
-More settings will be added to this file in future versions.
+The main place customisations go is the `src/config.json` file. The full list of
+available settings, with descriptions, types, and defaults, is in the
+[configuration documentation](docs/config_reference.md). That page is generated
+from `src/configSchema.json` (run `npm run docs:generate` after changing the
+schema); `npm start` and `npm run build` validate your `config.json` against the
+same schema and will fail with a clear error if a setting is missing or
+malformed.
 
 To customise the site heading, edit the `src/components/Header.js` file.
 
@@ -307,7 +153,7 @@ For hosting in a subdirectory, this should be altered as follows:
 
 The ConClár file format is designed to be compatible with KonOpas, and in most cases data files for KonOpas can be used without modification.
 
-Full details of the file format are in a separate [Data Structure document](https://github.com/lostcarpark/conclar/blob/main/docs/conclar_file_specs.md).
+Full details of the file format are in a separate [Data Structure document](docs/conclar_file_specs.md).
 
 ## Syncing selections across devices
 
@@ -315,7 +161,11 @@ By default, users' programme selections are stored only in the browser's local s
 
 If you want selections to sync automatically across devices, you can set up a sync server. When configured, users can log in and their selections will be saved to the server and loaded on any device they sign in to.
 
-To enable sync, add the `SYNC` section to your `config.json` with at least an `API_URL` pointing to your server. See the `SYNC.*` settings in the Customisation section above for the available options. If you don't need sync, simply leave the `SYNC` section out of your config and everything else works as normal.
+To enable sync, add the `SYNC` section to your `config.json` with at least an
+`API_URL` pointing to your server. See the `SYNC.*` settings in [configuration
+document](docs/config_reference.md) for the available options. If you don't need sync,
+simply leave the `SYNC` section out of your config and everything else works as
+normal.
 
 The sync server API is documented in [docs/sync_server_api.md](docs/sync_server_api.md). You can find an example server in [example-server](example-server), though this should never be used in production.
 

--- a/docs/config_reference.md
+++ b/docs/config_reference.md
@@ -1,0 +1,243 @@
+# ConClár configuration reference
+
+This document is generated from `src/configSchema.json` via `npm run docs:generate`. Do not edit it by hand — edit the schema instead and regenerate.
+
+Copy `src/config_example.json` to `src/config.json` and customise. See the [Getting Started](../README.md#getting-started) section of the README for details.
+
+- `APP_ID` (string, required) — A unique id to distinguish between instances of multi-year conventions.
+- `APP_TITLE` (string, required) — The title to appear at the top of the webpage, and in the browser window title.
+- `PROGRAM_DATA_URL` (string) — Legacy config for the address of the file containing programme data, in the bare-array format. If the same as PEOPLE_DATA_URL, both will be read from one file, but programme data must come before people data. Mutually exclusive with DATA_URLS; exactly one of DATA_URLS or the PROGRAM_DATA_URL/PEOPLE_DATA_URL pair must be given.
+- `PEOPLE_DATA_URL` (string) — Legacy config for the address of the file containing people data, in the bare-array format. If the same as PROGRAM_DATA_URL, both will be read from one file, but programme data must come before people data. Mutually exclusive with DATA_URLS; exactly one of DATA_URLS or the PROGRAM_DATA_URL/PEOPLE_DATA_URL pair must be given.
+- `DATA_URLS` (object) — The address(es) of the schedule/people data files, in the self-describing schemaVersion object format. Specify COMBINED for both from one file, or SCHEDULE and PEOPLE together for separate files. Specifying both COMBINED and SCHEDULE/PEOPLE together, or only one of SCHEDULE/PEOPLE, is a config error, enforced at validation time rather than by this schema. Mutually exclusive with PROGRAM_DATA_URL/PEOPLE_DATA_URL; exactly one of DATA_URLS or that legacy pair must be given. See docs/conclar_file_specs.md for the fetched file format.
+- `DATA_URLS.COMBINED` (string) — Address of a single file containing both schedule and people data. Mutually exclusive with SCHEDULE/PEOPLE.
+- `DATA_URLS.SCHEDULE` (string) — Address of the file containing schedule data. Must be given together with PEOPLE.
+- `DATA_URLS.PEOPLE` (string) — Address of the file containing people data. Must be given together with SCHEDULE.
+- `FETCH_OPTIONS` (object) — Options to pass when fetching data. See JavaScript fetch() documentation for the full set of available values; any option not listed below is still accepted and passed through.
+- `FETCH_OPTIONS.cache` (string) — Should generally be set to "reload" so back-end program updates will be read rather than served from the browser cache.
+- `FETCH_OPTIONS.credentials` (string) — Set to "omit" if the data source is not using a certificate from a recognised authority, e.g. a self-signed cert.
+- `FETCH_OPTIONS.headers` (object) — Headers sent in the fetch. Origin may be required for Cross Origin Resource Sharing (CORS).
+- `FETCH_OPTIONS_FIRST` (object) — Same as FETCH_OPTIONS, but used only for the first fetch of data (e.g. to allow different credentials/cache behaviour on initial load).
+- `FETCH_OPTIONS_FIRST.cache` (string)
+- `FETCH_OPTIONS_FIRST.credentials` (string)
+- `FETCH_OPTIONS_FIRST.headers` (object)
+- `TIMEZONE` (string, required) — The name of the timezone where your convention takes place (e.g. "Europe/Dublin"). Viewers outside convention timezone will see times in convention time, and their local time below it.
+- `TIMEZONECODE` (string, required) — The short code for the convention timezone (e.g. "IST"). Set to an empty string to get the browser's code for the timezone (not recommended, as it may not select the most elegant short code). Must be present (may be empty) - the app reads it unconditionally when displaying local time.
+- `INTERACTIVE` (boolean) — Set to false to get a non-interactive, expanded view of the schedule. The info page is also included, but not the participant list, individual participant pages, or individual item pages (regardless of the PERMALINK.SHOW_PERMALINK setting).
+- `HEADER` (object, required) — Add an optional image to the header of the pages.
+- `HEADER.IMG_SRC` (string) — Set to the image filename to display. May be a file in the public directory. Leave blank for no image.
+- `HEADER.IMG_ALT_TEXT` (string) — Set to the alt text that should display for the image.
+- `HEADER.LINEFEED_AFTER_URL` (boolean) — If true, place a line feed after the image.
+- `NAVIGATION` (object, required) — Each value in this section sets the label that will appear on main navigation of the site. Useful for switching between different international spellings of "programme".
+- `NAVIGATION.PROGRAM` (string) — Label for program/programme menu.
+- `NAVIGATION.PEOPLE` (string) — Label for people menu.
+- `NAVIGATION.MYSCHEDULE` (string) — Label for user's personal schedule.
+- `NAVIGATION.INFO` (string) — Label for the Information menu link.
+- `NAVIGATION.SETTINGS` (string) — Label for the Settings menu link.
+- `NAVIGATION.EXTRA` (array of object) — An array of extra menu links. To have no extra links, set to an empty array or omit EXTRA entirely.
+- `NAVIGATION.EXTRA[].LABEL` (string) — Text of the extra navigation link.
+- `NAVIGATION.EXTRA[].URL` (string) — URL the extra navigation link points to.
+- `NAVIGATION.EXTRA[].ICON_NAME` (string) — Name of a built-in icon to show before the label, e.g. "Home". Available names: Discord, Envelope, Facebook, Globe, Home, Instagram, Map, Mastodon, PaperPlane, Question, Sign, Ticket, Twitter, Youtube. (To add more, see iconsByName in src/components/NavIcon.js.) If both ICON_NAME and ICON_URL are given, ICON_NAME takes precedence.
+- `NAVIGATION.EXTRA[].ICON_URL` (string) — URL of an image to use as the icon instead of a built-in one. Used only if ICON_NAME isn't given.
+- `HELP_TEXT` (object) — Text shown to new visitors to introduce the site's features.
+- `HELP_TEXT.WELCOME` (string) — Text to display to new visitors who haven't selected any programme items.
+- `HELP_TEXT.SHARING` (string) — Text to display when user has selected items, informing them of sharing options.
+- `HELP_TEXT.CLOSE_ARIA_LABEL` (string) — Label to describe dismiss button.
+- `LOCATIONS` (object) — Configures the location filter and optional links to maps for each location.
+- `LOCATIONS.SEARCHABLE` (boolean) — Whether the location list can be searched by typing. (Searching can be inconvenient on touch screens.)
+- `LOCATIONS.LABEL` (string) — Label to show on map links.
+- `LOCATIONS.MAPPING` (array of object) — Array of locations, with links to show on map.
+- `LOCATIONS.MAPPING[].KEY` (string) — Room name, matching the location name used in the programme data.
+- `LOCATIONS.MAPPING[].MAP_URL` (string) — Link to a map for this location.
+- `VENUES` (object) — Groups locations by venue, for conventions spanning more than one building. If omitted, the locations drop-down is a flat, ungrouped list.
+- `VENUES.ALL_LABEL` (string) — Label template for the "select this whole venue" option shown at the top of each venue's group in the locations drop-down. @venue is replaced with the venue name. Defaults to "All @venue".
+- `VENUES.UNGROUPED_LABEL` (string) — Label for the group heading shown above locations that aren't listed under any venue. Defaults to "Other".
+- `VENUES.MAPPING` (array of object) — Array of venues. Venues are listed in the locations drop-down in the order given here. A location may only belong to one venue; locations not listed under any venue are shown grouped under UNGROUPED_LABEL, below the venue groups. Selecting a venue's "All <venue>" option shows every programme item in any of that venue's locations. Venue names must be unique and a location may not be assigned to more than one venue - enforced at validation time, not by this schema.
+- `VENUES.MAPPING[].NAME` (string) — Venue name, shown in the locations drop-down.
+- `VENUES.MAPPING[].LOCATIONS` (array of string) — Location names (matching LOCATIONS.MAPPING keys / programme data location names) that belong to this venue.
+- `APPLICATION` (object, required) — General application-wide settings.
+- `APPLICATION.LOADING` (object)
+- `APPLICATION.LOADING.MESSAGE` (string) — Message to display while loading.
+- `PROGRAM` (object, required) — Settings for the main programme list, My Schedule, and shared-items pages.
+- `PROGRAM.LIMIT` (object) — Controls the "maximum items displayed" drop-down on the programme page.
+- `PROGRAM.LIMIT.SHOW` (boolean) — If true, "limit number of items" drop-down will be displayed.
+- `PROGRAM.LIMIT.LABEL` (string) — Label for limit drop-down.
+- `PROGRAM.LIMIT.OPTIONS` (array of integer) — Options for the limit drop-down.
+- `PROGRAM.LIMIT.ALL_LABEL` (string) — Label to show for the "All" entry.
+- `PROGRAM.LIMIT.DEFAULT` (integer) — Default value for the limit drop-down.
+- `PROGRAM.LIMIT.SHOW_MORE` (object)
+- `PROGRAM.LIMIT.SHOW_MORE.LABEL` (string) — Label for the "Show more" button.
+- `PROGRAM.LIMIT.SHOW_MORE.NO_MORE` (string) — Message to display when no more items are available.
+- `PROGRAM.LIMIT.SHOW_MORE.NUM_EXTRA` (integer) — Number of items to add when "Show more" is pressed.
+- `PROGRAM.SEARCH` (object)
+- `PROGRAM.SEARCH.SEARCH_LABEL` (string) — Placeholder for the programme search box.
+- `PROGRAM.MY_SCHEDULE` (object) — Settings for the My Schedule page.
+- `PROGRAM.MY_SCHEDULE.TITLE` (string) — Title of My Schedule page.
+- `PROGRAM.MY_SCHEDULE.EMPTY` (object)
+- `PROGRAM.MY_SCHEDULE.EMPTY.TEXT` (string) — Text to display on My Schedule when no programme items are selected.
+- `PROGRAM.MY_SCHEDULE.INTRO` (string) — Introduction text for the My Schedule page.
+- `PROGRAM.MY_SCHEDULE.SHARE` (object) — Settings for the QR code / link sharing section of My Schedule.
+- `PROGRAM.MY_SCHEDULE.SHARE.LABEL` (string) — Heading for the shared link section on My Schedule.
+- `PROGRAM.MY_SCHEDULE.SHARE.DESCRIPTION` (string) — Descriptive message for the link sharing section.
+- `PROGRAM.MY_SCHEDULE.SHARE.LINK_LABEL` (string) — Label for the link when there is a single sharing link on the page.
+- `PROGRAM.MY_SCHEDULE.SHARE.MAX_LENGTH` (integer) — Maximum number of characters in each shareable link.
+- `PROGRAM.MY_SCHEDULE.SHARE.MULTIPLE_DESCRIPTION` (string) — Description to display when multiple links are shown.
+- `PROGRAM.MY_SCHEDULE.SHARE.MULTIPLE_LINK_LABEL` (string) — Label for a link when multiple links are shown. @number is replaced by the link's number.
+- `PROGRAM.SHARED` (object) — Settings for the page showing programme items shared via a link.
+- `PROGRAM.SHARED.TITLE` (string) — Title of the Shared Programme Items page.
+- `PROGRAM.SHARED.DESCRIPTION` (string) — Descriptive text for the page showing shared items.
+- `PROGRAM.SHARED.BUTTON_LABEL` (string) — Text for the "Add all to My Schedule" button.
+- `TAGS` (object) — Settings for the tag filter on the programme page.
+- `TAGS.PLACEHOLDER` (string) — The placeholder when selecting tags (unless separated).
+- `TAGS.SEARCHABLE` (boolean) — Whether the tag list can be searched by typing (unless separated).
+- `TAGS.HIDE` (boolean) — If true, hide the tags drop-down. Tags are still displayed on items.
+- `TAGS.SEPARATE` (array of object) — An array of tag prefixes to separate into individual drop-downs.
+- `TAGS.SEPARATE[].PREFIX` (string) — Tag prefix to separate out into its own drop-down, e.g. "type".
+- `TAGS.SEPARATE[].PLACEHOLDER` (string) — Placeholder for this drop-down.
+- `TAGS.SEPARATE[].SEARCHABLE` (boolean) — Whether this drop-down can be searched by typing.
+- `TAGS.SEPARATE[].HIDE` (boolean) — If true, hide this drop-down. Tags are still displayed on items.
+- `TAGS.FORMAT_AS_TAG` (boolean) — If set to true, turns Grenadine item format into a KonOpas-style "type" tag.
+- `TAGS.DAY_TAG` (object) — Settings for auto-generated per-day tags.
+- `TAGS.DAY_TAG.GENERATE` (boolean) — If set to true, will generate tags for each day of the convention.
+- `TAGS.DAY_TAG.DAYS` (object) — Key/value pairs mapping ISO weekday numbers (1 = Monday .. 7 = Sunday) to day names.
+- `TAGS.DAY_TAG.PLACEHOLDER` (string) — The placeholder for the "day" tags drop-down.
+- `TAGS.DAY_TAG.SEARCHABLE` (boolean) — Whether the day tag list can be searched by typing.
+- `TAGS.DAY_TAG.HIDE` (boolean) — If true, hide the day tags drop-down. Day tags are still shown on items if GENERATE is true.
+- `TAGS.DONTLIST` (array of string) — An array of tags not to list in the drop-downs and programme item tag lists.
+- `HIDE_BEFORE` (object) — Settings for the "hide items before this time" filter.
+- `HIDE_BEFORE.HIDE` (boolean) — If true, hide the "hide before" dropdown. If false, show a dropdown containing times to hide items before.
+- `HIDE_BEFORE.PLACEHOLDER` (string) — Placeholder text for the hide-before drop-down.
+- `HIDE_BEFORE.TIMES` (array of object) — Array of times to list in the hide-before drop-down. Times should be in convention timezone.
+- `HIDE_BEFORE.TIMES[].TIME` (string) — Time in hh:mm:ss format.
+- `HIDE_BEFORE.TIMES[].LABEL_24H` (string) — 24-hour format label for this time.
+- `HIDE_BEFORE.TIMES[].LABEL_12H` (string) — 12-hour format label for this time.
+- `FILTER` (object)
+- `FILTER.RESET` (object)
+- `FILTER.RESET.LABEL` (string) — The label for the "Reset filters" button.
+- `PERMALINK` (object)
+- `PERMALINK.SHOW_PERMALINK` (boolean) — If true, display a "permalink" icon when each program item is expanded.
+- `PERMALINK.PERMALINK_TITLE` (string) — "Title" text displayed when the mouse is hovered over the permalink icon.
+- `CALENDARLINK` (object)
+- `CALENDARLINK.SHOW` (boolean) — If true, display a calendar download icon when each program item is expanded.
+- `CALENDARLINK.TITLE` (string) — "Title" text displayed when the mouse is hovered over the calendar download icon.
+- `EXPAND` (object)
+- `EXPAND.EXPAND_ALL_LABEL` (string) — Label text for the Expand All button.
+- `EXPAND.COLLAPSE_ALL_LABEL` (string) — Label for the Collapse All button.
+- `EXPAND.SPRING_CONFIG` (object) — Config for the 'spring' animation used when expanding items. May be a simple duration, e.g. { "duration": 100 } to expand in 100ms, or can configure more dynamic spring effects, e.g. { "mass": 1, "tension": 1000, "friction": 30 }. Full list of options in the react-spring documentation (https://react-spring.io/common/configs).
+- `ITEM_DESCRIPTION` (object)
+- `ITEM_DESCRIPTION.PURIFY_OPTIONS` (object) — Additional options passed to DOMPurify when processing item descriptions. For the available options, see the DOMPurify documentation (https://github.com/cure53/DOMPurify#can-i-configure-dompurify).
+- `ITEM_DESCRIPTION.PURIFY_OPTIONS.FORBID_ATTR` (array of string)
+- `LINKS` (array of object) — An array of link types expected in the program data.
+- `LINKS[].NAME` (string) — The name of the link as it appears in the links object in the program data.
+- `LINKS[].TEXT` (string) — The text that should appear on this link in ConClár.
+- `LINKS[].TAG` (string) — An optional tag to add to every program item which includes a matching link. If using prefixed tags, include the prefix, e.g. "type:Workshop".
+- `LINKS[].WHEN` (array of string) — An optional array listing times when the link will be visible. Multiple values may be given, e.g. ["before", "during"], meaning the link is visible prior to the item and while it is happening, but disappears when it finishes. If omitted, the link is always visible.
+- `CONVENTION_TIME` (object)
+- `CONVENTION_TIME.NOTICE` (string) — Notice explaining that displayed times are convention time. @timezone is replaced with the convention timezone.
+- `LOCAL_TIME` (object)
+- `LOCAL_TIME.CHECKBOX_LABEL` (string) — Label for the "Show Local Time" checkbox.
+- `LOCAL_TIME.NOTICE` (string) — Notice telling users how local time is displayed. @timezone is replaced with the convention timezone.
+- `LOCAL_TIME.PREV_DAY` (string) — Label appended to local time if local time is before the start of the advertised day.
+- `LOCAL_TIME.NEXT_DAY` (string) — Label appended to local time if local time is after the end of the advertised day.
+- `LOCAL_TIME.FAILURE` (string) — Local time depends on string conversions, and could fail in some circumstances. Message to display if unable to convert.
+- `TIME_FORMAT` (object)
+- `TIME_FORMAT.DEFAULT_12HR` (boolean) — Set to true if you want time displayed in 12-hour format by default.
+- `TIME_FORMAT.SHOW_CHECKBOX` (boolean) — If set to false, users will not be given the option to change between 12 and 24 hour time.
+- `TIME_FORMAT.CHECKBOX_LABEL` (string) — Label for the 12-hour time checkbox.
+- `TIME_FORMAT.AM` (string) — Label for AM times.
+- `TIME_FORMAT.PM` (string) — Label for PM times.
+- `DURATION` (object)
+- `DURATION.SHOW_DURATION` (boolean) — If true, minutes from program data will be displayed.
+- `DURATION.DURATION_LABEL` (string) — Format for duration. @mins is replaced by the number of minutes. Do not translate @mins.
+- `START_TIME` (object)
+- `START_TIME.START_TIME_LABEL` (string) — Format for start time with just convention time, read by screen readers. @con_time is replaced by the start time. Do not translate @con_time.
+- `START_TIME.START_TIME_WITH_LOCAL_LABEL` (string) — Format for start time with both convention and local time, read by screen readers. @con_time and @local_time are replaced by the start times. Do not translate @con_time or @local_time.
+- `SHOW_PAST_ITEMS` (object)
+- `SHOW_PAST_ITEMS.SHOW_CHECKBOX` (boolean) — Set to true to show the "show past items" option during the convention; otherwise past programme items are shown by default.
+- `SHOW_PAST_ITEMS.CHECKBOX_LABEL` (string) — Label for the show-past-items checkbox.
+- `SHOW_PAST_ITEMS.ADJUST_MINUTES` (number) — Some wiggle room (in minutes) in order not to hide past items immediately as they start.
+- `SHOW_PAST_ITEMS.FROM_START` (boolean) — If true, adjust from the item's start time rather than its end time when deciding whether it's "past".
+- `PEOPLE` (object) — Settings for the people list and individual participant pages.
+- `PEOPLE.MODERATORS` (object)
+- `PEOPLE.MODERATORS.MODERATOR_LABEL` (string) — Label appended to a participant's name when they are the moderator of an item.
+- `PEOPLE.THUMBNAILS` (object)
+- `PEOPLE.THUMBNAILS.SHOW_THUMBNAILS` (boolean) — Set to false to not show member thumbnails (useful to remove spurious controls if pictures aren't in the data file).
+- `PEOPLE.THUMBNAILS.SHOW_CHECKBOX` (boolean) — Set to false to hide the "Show thumbnails" checkbox.
+- `PEOPLE.THUMBNAILS.CHECKBOX_LABEL` (string) — Label for the "Show thumbnails" checkbox.
+- `PEOPLE.THUMBNAILS.DEFAULT_IMAGE` (string) — Default thumbnail for participants with no photo. Can be a filename of an image in the public directory, or an external URL. Leave blank for no default thumbnail.
+- `PEOPLE.SORT` (object)
+- `PEOPLE.SORT.SHOW_CHECKBOX` (boolean) — Set to false to hide the "Sort by full name" checkbox. Useful if your data only contains "name for publications".
+- `PEOPLE.SORT.CHECKBOX_LABEL` (string) — Label for the "Sort by full name" checkbox.
+- `PEOPLE.TAGS` (object) — Settings for the tag filter on the people page. Same shape as the top-level TAGS section, but without DAY_TAG/FORMAT_AS_TAG/DONTLIST.
+- `PEOPLE.TAGS.PLACEHOLDER` (string) — The placeholder when selecting person tags (unless separated).
+- `PEOPLE.TAGS.SEARCHABLE` (boolean) — Whether the tag list can be searched by typing (unless separated).
+- `PEOPLE.TAGS.HIDE` (boolean) — If true, hide the tags drop-down. Tags are still displayed on people.
+- `PEOPLE.TAGS.SEPARATE` (array of object) — An array of tag prefixes to separate into individual drop-downs.
+- `PEOPLE.TAGS.SEPARATE[].PREFIX` (string)
+- `PEOPLE.TAGS.SEPARATE[].PLACEHOLDER` (string)
+- `PEOPLE.TAGS.SEPARATE[].SEARCHABLE` (boolean)
+- `PEOPLE.TAGS.SEPARATE[].HIDE` (boolean)
+- `PEOPLE.SEARCH` (object)
+- `PEOPLE.SEARCH.SHOW_SEARCH` (boolean) — Set to false to hide the people search box.
+- `PEOPLE.SEARCH.SEARCH_LABEL` (string) — Label for the people search box.
+- `PEOPLE.PERSON_HEADER` (string) — Prefix shown before a participant's name on their individual page.
+- `PEOPLE.BIO` (object)
+- `PEOPLE.BIO.PURIFY_OPTIONS` (object) — Additional options passed to DOMPurify when processing participant bios. For more details, see ITEM_DESCRIPTION.PURIFY_OPTIONS.
+- `PEOPLE.BIO.PURIFY_OPTIONS.FORBID_ATTR` (array of string)
+- `USELESS_CHECKBOX` (object)
+- `USELESS_CHECKBOX.CHECKBOX_LABEL` (string) — Label for any "useless" placeholder checkboxes used for layout alignment.
+- `INFORMATION` (object, required)
+- `INFORMATION.MARKDOWN_URL` (string) — The address of the Markdown file containing additional information about the convention. May be a relative path to a file in the public directory.
+- `INFORMATION.LOADING_MESSAGE` (string) — Text to show while the Markdown file is loading (usually never seen).
+- `SETTINGS` (object, required) — Labels for the Settings page.
+- `SETTINGS.TITLE` (object)
+- `SETTINGS.TITLE.LABEL` (string) — Label for the settings page.
+- `SETTINGS.TIME_FORMAT` (object)
+- `SETTINGS.TIME_FORMAT.LABEL` (string) — Label for the time format option group.
+- `SETTINGS.TIME_FORMAT.T12_HOUR_LABEL` (string) — Label for the 12 hour option.
+- `SETTINGS.TIME_FORMAT.T24_HOUR_LABEL` (string) — Label for the 24 hour option.
+- `SETTINGS.SHOW_LOCAL_TIME` (object)
+- `SETTINGS.SHOW_LOCAL_TIME.LABEL` (string) — Label for the Show Local Time option group.
+- `SETTINGS.SHOW_LOCAL_TIME.NEVER_LABEL` (string) — Label for the "Never show" option.
+- `SETTINGS.SHOW_LOCAL_TIME.DIFFERS_LABEL` (string) — Label for "Display if different from convention timezone".
+- `SETTINGS.SHOW_LOCAL_TIME.ALWAYS_LABEL` (string) — Label for the "Always display" option.
+- `SETTINGS.SHOW_TIMEZONE` (object)
+- `SETTINGS.SHOW_TIMEZONE.LABEL` (string) — Label for the "Show timezone after times" option group.
+- `SETTINGS.SHOW_TIMEZONE.NEVER_LABEL` (string) — Label for the "Never show" option.
+- `SETTINGS.SHOW_TIMEZONE.IF_LOCAL_LABEL` (string) — Label for "Show timezone if local time shown".
+- `SETTINGS.SHOW_TIMEZONE.ALWAYS_LABEL` (string) — Label for the "Always show" option.
+- `SETTINGS.SELECT_TIMEZONE` (object)
+- `SETTINGS.SELECT_TIMEZONE.LABEL` (string) — Label for the select-timezone group.
+- `SETTINGS.SELECT_TIMEZONE.BROWSER_DEFAULT_LABEL` (string) — Label to use the browser default timezone (will have the timezone name appended).
+- `SETTINGS.SELECT_TIMEZONE.SELECT_LABEL` (string) — Label to select an explicit timezone.
+- `SETTINGS.DARK_MODE` (object)
+- `SETTINGS.DARK_MODE.LABEL` (string) — Label for the dark mode settings group.
+- `SETTINGS.DARK_MODE.BROWSER_DEFAULT_LABEL` (string) — Label for the default browser dark-mode preference option.
+- `SETTINGS.DARK_MODE.BROWSER_LIGHT_LABEL` (string) — Label indicating the browser is currently in light mode.
+- `SETTINGS.DARK_MODE.BROWSER_DARK_LABEL` (string) — Label indicating the browser is currently in dark mode.
+- `SETTINGS.DARK_MODE.LIGHT_MODE_LABEL` (string) — Label for forcing light mode.
+- `SETTINGS.DARK_MODE.DARK_MODE_LABEL` (string) — Label for forcing dark mode.
+- `FOOTER` (object, required)
+- `FOOTER.SITE_NOTE_MARKDOWN` (string) — General note displayed in the footer of the page. May use Markdown for links, emphasis, etc.
+- `FOOTER.COPYRIGHT_MARKDOWN` (string) — Copyright notice, if required. May include Markdown.
+- `FOOTER.CONCLAR_NOTE_MARKDOWN` (string) — Note crediting ConClár. Free to remove or modify, but retaining it is politely requested to help promote this free tool.
+- `TIMER` (object, required)
+- `TIMER.FETCH_INTERVAL_MINS` (number) — Number of minutes between refreshes of program data.
+- `TIMER.TIMER_TICK_SECS` (number) — Number of seconds between checks of the timer.
+- `DEBUG_MODE` (object, required)
+- `DEBUG_MODE.ENABLE` (boolean) — If true, display a banner showing online status, and allowing manual data fetch.
+- `DEBUG_MODE.ONLINE_LABEL` (string) — Label to display in debug mode when online.
+- `DEBUG_MODE.OFFLINE_LABEL` (string) — Label to display in debug mode when offline.
+- `DEBUG_MODE.FETCH_BUTTON_LABEL` (string) — Label to display in debug mode on the Fetch button.
+- `SYNC` (object) — Enables syncing programme selections across devices via a sync server. If omitted, or if API_URL is empty, sync is disabled entirely and everything else works as normal (selections stay in browser local storage / QR-code sharing only). The sync server API is documented in docs/sync_server_api.md.
+- `SYNC.API_URL` (string) — The base URL of your sync server API, e.g. "https://auth.example-con.org/api". If omitted or empty, sync is disabled entirely.
+- `SYNC.LOADING_LABEL` (string) — Label shown while the profile is being fetched on startup.
+- `SYNC.LOGIN_LABEL` (string) — Label for the login link when the user is not authenticated.
+- `SYNC.LOGOUT_LABEL` (string) — Label for the logout link. @display_name is replaced with the user's display name.
+- `SYNC.ERROR_LABEL` (string) — Label for the error message when unable to connect to the sync server.
+- `SYNC.WARNING` (object) — The popup shown the first time an unauthenticated user adds or removes a selection, prompting them to log in.
+- `SYNC.WARNING.HEADING` (string) — Heading of the sync warning popup.
+- `SYNC.WARNING.TITLE` (string) — Main message body of the sync warning popup.
+- `SYNC.WARNING.DETAILS` (string) — Expandable detail text shown when the user clicks "More information" in the sync warning popup.
+- `SYNC.WARNING.DETAILS_LABEL` (string) — Label for the button that expands the detail text in the sync warning popup.
+- `SYNC.WARNING.LOGIN_LABEL` (string) — Label for the primary login button in the sync warning popup.
+- `SYNC.WARNING.DISMISS_LABEL` (string) — Label for the dismiss link in the sync warning popup.

--- a/docs/config_reference.md
+++ b/docs/config_reference.md
@@ -28,11 +28,11 @@ Copy `src/config_example.json` to `src/config.json` and customise. See the [Gett
 - `HEADER.IMG_ALT_TEXT` (string) — Set to the alt text that should display for the image.
 - `HEADER.LINEFEED_AFTER_URL` (boolean) — If true, place a line feed after the image.
 - `NAVIGATION` (object, required) — Each value in this section sets the label that will appear on main navigation of the site. Useful for switching between different international spellings of "programme".
-- `NAVIGATION.PROGRAM` (string) — Label for program/programme menu.
-- `NAVIGATION.PEOPLE` (string) — Label for people menu.
-- `NAVIGATION.MYSCHEDULE` (string) — Label for user's personal schedule.
+- `NAVIGATION.PROGRAM` (string, required) — Label for program/programme menu.
+- `NAVIGATION.PEOPLE` (string, required) — Label for people menu.
+- `NAVIGATION.MYSCHEDULE` (string, required) — Label for user's personal schedule.
 - `NAVIGATION.INFO` (string) — Label for the Information menu link.
-- `NAVIGATION.SETTINGS` (string) — Label for the Settings menu link.
+- `NAVIGATION.SETTINGS` (string, required) — Label for the Settings menu link.
 - `NAVIGATION.EXTRA` (array of object) — An array of extra menu links. To have no extra links, set to an empty array or omit EXTRA entirely.
 - `NAVIGATION.EXTRA[].LABEL` (string) — Text of the extra navigation link.
 - `NAVIGATION.EXTRA[].URL` (string) — URL the extra navigation link points to.
@@ -55,37 +55,37 @@ Copy `src/config_example.json` to `src/config.json` and customise. See the [Gett
 - `VENUES.MAPPING[].NAME` (string) — Venue name, shown in the locations drop-down.
 - `VENUES.MAPPING[].LOCATIONS` (array of string) — Location names (matching LOCATIONS.MAPPING keys / programme data location names) that belong to this venue.
 - `APPLICATION` (object, required) — General application-wide settings.
-- `APPLICATION.LOADING` (object)
-- `APPLICATION.LOADING.MESSAGE` (string) — Message to display while loading.
+- `APPLICATION.LOADING` (object, required)
+- `APPLICATION.LOADING.MESSAGE` (string, required) — Message to display while loading.
 - `PROGRAM` (object, required) — Settings for the main programme list, My Schedule, and shared-items pages.
-- `PROGRAM.LIMIT` (object) — Controls the "maximum items displayed" drop-down on the programme page.
+- `PROGRAM.LIMIT` (object, required) — Controls the "maximum items displayed" drop-down on the programme page.
 - `PROGRAM.LIMIT.SHOW` (boolean) — If true, "limit number of items" drop-down will be displayed.
 - `PROGRAM.LIMIT.LABEL` (string) — Label for limit drop-down.
 - `PROGRAM.LIMIT.OPTIONS` (array of integer) — Options for the limit drop-down.
 - `PROGRAM.LIMIT.ALL_LABEL` (string) — Label to show for the "All" entry.
-- `PROGRAM.LIMIT.DEFAULT` (integer) — Default value for the limit drop-down.
-- `PROGRAM.LIMIT.SHOW_MORE` (object)
-- `PROGRAM.LIMIT.SHOW_MORE.LABEL` (string) — Label for the "Show more" button.
-- `PROGRAM.LIMIT.SHOW_MORE.NO_MORE` (string) — Message to display when no more items are available.
-- `PROGRAM.LIMIT.SHOW_MORE.NUM_EXTRA` (integer) — Number of items to add when "Show more" is pressed.
-- `PROGRAM.SEARCH` (object)
-- `PROGRAM.SEARCH.SEARCH_LABEL` (string) — Placeholder for the programme search box.
-- `PROGRAM.MY_SCHEDULE` (object) — Settings for the My Schedule page.
-- `PROGRAM.MY_SCHEDULE.TITLE` (string) — Title of My Schedule page.
-- `PROGRAM.MY_SCHEDULE.EMPTY` (object)
-- `PROGRAM.MY_SCHEDULE.EMPTY.TEXT` (string) — Text to display on My Schedule when no programme items are selected.
-- `PROGRAM.MY_SCHEDULE.INTRO` (string) — Introduction text for the My Schedule page.
-- `PROGRAM.MY_SCHEDULE.SHARE` (object) — Settings for the QR code / link sharing section of My Schedule.
-- `PROGRAM.MY_SCHEDULE.SHARE.LABEL` (string) — Heading for the shared link section on My Schedule.
-- `PROGRAM.MY_SCHEDULE.SHARE.DESCRIPTION` (string) — Descriptive message for the link sharing section.
-- `PROGRAM.MY_SCHEDULE.SHARE.LINK_LABEL` (string) — Label for the link when there is a single sharing link on the page.
-- `PROGRAM.MY_SCHEDULE.SHARE.MAX_LENGTH` (integer) — Maximum number of characters in each shareable link.
-- `PROGRAM.MY_SCHEDULE.SHARE.MULTIPLE_DESCRIPTION` (string) — Description to display when multiple links are shown.
-- `PROGRAM.MY_SCHEDULE.SHARE.MULTIPLE_LINK_LABEL` (string) — Label for a link when multiple links are shown. @number is replaced by the link's number.
-- `PROGRAM.SHARED` (object) — Settings for the page showing programme items shared via a link.
-- `PROGRAM.SHARED.TITLE` (string) — Title of the Shared Programme Items page.
-- `PROGRAM.SHARED.DESCRIPTION` (string) — Descriptive text for the page showing shared items.
-- `PROGRAM.SHARED.BUTTON_LABEL` (string) — Text for the "Add all to My Schedule" button.
+- `PROGRAM.LIMIT.DEFAULT` (integer, required) — Default value for the limit drop-down.
+- `PROGRAM.LIMIT.SHOW_MORE` (object, required)
+- `PROGRAM.LIMIT.SHOW_MORE.LABEL` (string, required) — Label for the "Show more" button.
+- `PROGRAM.LIMIT.SHOW_MORE.NO_MORE` (string, required) — Message to display when no more items are available.
+- `PROGRAM.LIMIT.SHOW_MORE.NUM_EXTRA` (integer, required) — Number of items to add when "Show more" is pressed.
+- `PROGRAM.SEARCH` (object, required)
+- `PROGRAM.SEARCH.SEARCH_LABEL` (string, required) — Placeholder for the programme search box.
+- `PROGRAM.MY_SCHEDULE` (object, required) — Settings for the My Schedule page.
+- `PROGRAM.MY_SCHEDULE.TITLE` (string, required) — Title of My Schedule page.
+- `PROGRAM.MY_SCHEDULE.EMPTY` (object, required)
+- `PROGRAM.MY_SCHEDULE.EMPTY.TEXT` (string, required) — Text to display on My Schedule when no programme items are selected.
+- `PROGRAM.MY_SCHEDULE.INTRO` (string, required) — Introduction text for the My Schedule page.
+- `PROGRAM.MY_SCHEDULE.SHARE` (object, required) — Settings for the QR code / link sharing section of My Schedule.
+- `PROGRAM.MY_SCHEDULE.SHARE.LABEL` (string, required) — Heading for the shared link section on My Schedule.
+- `PROGRAM.MY_SCHEDULE.SHARE.DESCRIPTION` (string, required) — Descriptive message for the link sharing section.
+- `PROGRAM.MY_SCHEDULE.SHARE.LINK_LABEL` (string, required) — Label for the link when there is a single sharing link on the page.
+- `PROGRAM.MY_SCHEDULE.SHARE.MAX_LENGTH` (integer, required) — Maximum number of characters in each shareable link.
+- `PROGRAM.MY_SCHEDULE.SHARE.MULTIPLE_DESCRIPTION` (string, required) — Description to display when multiple links are shown.
+- `PROGRAM.MY_SCHEDULE.SHARE.MULTIPLE_LINK_LABEL` (string, required) — Label for a link when multiple links are shown. @number is replaced by the link's number.
+- `PROGRAM.SHARED` (object, required) — Settings for the page showing programme items shared via a link.
+- `PROGRAM.SHARED.TITLE` (string, required) — Title of the Shared Programme Items page.
+- `PROGRAM.SHARED.DESCRIPTION` (string, required) — Descriptive text for the page showing shared items.
+- `PROGRAM.SHARED.BUTTON_LABEL` (string, required) — Text for the "Add all to My Schedule" button.
 - `TAGS` (object) — Settings for the tag filter on the programme page.
 - `TAGS.PLACEHOLDER` (string) — The placeholder when selecting tags (unless separated).
 - `TAGS.SEARCHABLE` (boolean) — Whether the tag list can be searched by typing (unless separated).
@@ -186,43 +186,43 @@ Copy `src/config_example.json` to `src/config.json` and customise. See the [Gett
 - `USELESS_CHECKBOX` (object)
 - `USELESS_CHECKBOX.CHECKBOX_LABEL` (string) — Label for any "useless" placeholder checkboxes used for layout alignment.
 - `INFORMATION` (object, required)
-- `INFORMATION.MARKDOWN_URL` (string) — The address of the Markdown file containing additional information about the convention. May be a relative path to a file in the public directory.
+- `INFORMATION.MARKDOWN_URL` (string, required) — The address of the Markdown file containing additional information about the convention. May be a relative path to a file in the public directory.
 - `INFORMATION.LOADING_MESSAGE` (string) — Text to show while the Markdown file is loading (usually never seen).
 - `SETTINGS` (object, required) — Labels for the Settings page.
-- `SETTINGS.TITLE` (object)
-- `SETTINGS.TITLE.LABEL` (string) — Label for the settings page.
-- `SETTINGS.TIME_FORMAT` (object)
-- `SETTINGS.TIME_FORMAT.LABEL` (string) — Label for the time format option group.
-- `SETTINGS.TIME_FORMAT.T12_HOUR_LABEL` (string) — Label for the 12 hour option.
-- `SETTINGS.TIME_FORMAT.T24_HOUR_LABEL` (string) — Label for the 24 hour option.
-- `SETTINGS.SHOW_LOCAL_TIME` (object)
-- `SETTINGS.SHOW_LOCAL_TIME.LABEL` (string) — Label for the Show Local Time option group.
-- `SETTINGS.SHOW_LOCAL_TIME.NEVER_LABEL` (string) — Label for the "Never show" option.
-- `SETTINGS.SHOW_LOCAL_TIME.DIFFERS_LABEL` (string) — Label for "Display if different from convention timezone".
-- `SETTINGS.SHOW_LOCAL_TIME.ALWAYS_LABEL` (string) — Label for the "Always display" option.
-- `SETTINGS.SHOW_TIMEZONE` (object)
-- `SETTINGS.SHOW_TIMEZONE.LABEL` (string) — Label for the "Show timezone after times" option group.
-- `SETTINGS.SHOW_TIMEZONE.NEVER_LABEL` (string) — Label for the "Never show" option.
-- `SETTINGS.SHOW_TIMEZONE.IF_LOCAL_LABEL` (string) — Label for "Show timezone if local time shown".
-- `SETTINGS.SHOW_TIMEZONE.ALWAYS_LABEL` (string) — Label for the "Always show" option.
-- `SETTINGS.SELECT_TIMEZONE` (object)
-- `SETTINGS.SELECT_TIMEZONE.LABEL` (string) — Label for the select-timezone group.
-- `SETTINGS.SELECT_TIMEZONE.BROWSER_DEFAULT_LABEL` (string) — Label to use the browser default timezone (will have the timezone name appended).
-- `SETTINGS.SELECT_TIMEZONE.SELECT_LABEL` (string) — Label to select an explicit timezone.
-- `SETTINGS.DARK_MODE` (object)
-- `SETTINGS.DARK_MODE.LABEL` (string) — Label for the dark mode settings group.
-- `SETTINGS.DARK_MODE.BROWSER_DEFAULT_LABEL` (string) — Label for the default browser dark-mode preference option.
-- `SETTINGS.DARK_MODE.BROWSER_LIGHT_LABEL` (string) — Label indicating the browser is currently in light mode.
-- `SETTINGS.DARK_MODE.BROWSER_DARK_LABEL` (string) — Label indicating the browser is currently in dark mode.
-- `SETTINGS.DARK_MODE.LIGHT_MODE_LABEL` (string) — Label for forcing light mode.
-- `SETTINGS.DARK_MODE.DARK_MODE_LABEL` (string) — Label for forcing dark mode.
+- `SETTINGS.TITLE` (object, required)
+- `SETTINGS.TITLE.LABEL` (string, required) — Label for the settings page.
+- `SETTINGS.TIME_FORMAT` (object, required)
+- `SETTINGS.TIME_FORMAT.LABEL` (string, required) — Label for the time format option group.
+- `SETTINGS.TIME_FORMAT.T12_HOUR_LABEL` (string, required) — Label for the 12 hour option.
+- `SETTINGS.TIME_FORMAT.T24_HOUR_LABEL` (string, required) — Label for the 24 hour option.
+- `SETTINGS.SHOW_LOCAL_TIME` (object, required)
+- `SETTINGS.SHOW_LOCAL_TIME.LABEL` (string, required) — Label for the Show Local Time option group.
+- `SETTINGS.SHOW_LOCAL_TIME.NEVER_LABEL` (string, required) — Label for the "Never show" option.
+- `SETTINGS.SHOW_LOCAL_TIME.DIFFERS_LABEL` (string, required) — Label for "Display if different from convention timezone".
+- `SETTINGS.SHOW_LOCAL_TIME.ALWAYS_LABEL` (string, required) — Label for the "Always display" option.
+- `SETTINGS.SHOW_TIMEZONE` (object, required)
+- `SETTINGS.SHOW_TIMEZONE.LABEL` (string, required) — Label for the "Show timezone after times" option group.
+- `SETTINGS.SHOW_TIMEZONE.NEVER_LABEL` (string, required) — Label for the "Never show" option.
+- `SETTINGS.SHOW_TIMEZONE.IF_LOCAL_LABEL` (string, required) — Label for "Show timezone if local time shown".
+- `SETTINGS.SHOW_TIMEZONE.ALWAYS_LABEL` (string, required) — Label for the "Always show" option.
+- `SETTINGS.SELECT_TIMEZONE` (object, required)
+- `SETTINGS.SELECT_TIMEZONE.LABEL` (string, required) — Label for the select-timezone group.
+- `SETTINGS.SELECT_TIMEZONE.BROWSER_DEFAULT_LABEL` (string, required) — Label to use the browser default timezone (will have the timezone name appended).
+- `SETTINGS.SELECT_TIMEZONE.SELECT_LABEL` (string, required) — Label to select an explicit timezone.
+- `SETTINGS.DARK_MODE` (object, required)
+- `SETTINGS.DARK_MODE.LABEL` (string, required) — Label for the dark mode settings group.
+- `SETTINGS.DARK_MODE.BROWSER_DEFAULT_LABEL` (string, required) — Label for the default browser dark-mode preference option.
+- `SETTINGS.DARK_MODE.BROWSER_LIGHT_LABEL` (string, required) — Label indicating the browser is currently in light mode.
+- `SETTINGS.DARK_MODE.BROWSER_DARK_LABEL` (string, required) — Label indicating the browser is currently in dark mode.
+- `SETTINGS.DARK_MODE.LIGHT_MODE_LABEL` (string, required) — Label for forcing light mode.
+- `SETTINGS.DARK_MODE.DARK_MODE_LABEL` (string, required) — Label for forcing dark mode.
 - `FOOTER` (object, required)
 - `FOOTER.SITE_NOTE_MARKDOWN` (string) — General note displayed in the footer of the page. May use Markdown for links, emphasis, etc.
 - `FOOTER.COPYRIGHT_MARKDOWN` (string) — Copyright notice, if required. May include Markdown.
 - `FOOTER.CONCLAR_NOTE_MARKDOWN` (string) — Note crediting ConClár. Free to remove or modify, but retaining it is politely requested to help promote this free tool.
 - `TIMER` (object, required)
-- `TIMER.FETCH_INTERVAL_MINS` (number) — Number of minutes between refreshes of program data.
-- `TIMER.TIMER_TICK_SECS` (number) — Number of seconds between checks of the timer.
+- `TIMER.FETCH_INTERVAL_MINS` (number, required) — Number of minutes between refreshes of program data.
+- `TIMER.TIMER_TICK_SECS` (number, required) — Number of seconds between checks of the timer.
 - `DEBUG_MODE` (object, required)
 - `DEBUG_MODE.ENABLE` (boolean) — If true, display a banner showing online status, and allowing manual data fetch.
 - `DEBUG_MODE.ONLINE_LABEL` (string) — Label to display in debug mode when online.
@@ -235,9 +235,9 @@ Copy `src/config_example.json` to `src/config.json` and customise. See the [Gett
 - `SYNC.LOGOUT_LABEL` (string) — Label for the logout link. @display_name is replaced with the user's display name.
 - `SYNC.ERROR_LABEL` (string) — Label for the error message when unable to connect to the sync server.
 - `SYNC.WARNING` (object) — The popup shown the first time an unauthenticated user adds or removes a selection, prompting them to log in.
-- `SYNC.WARNING.HEADING` (string) — Heading of the sync warning popup.
-- `SYNC.WARNING.TITLE` (string) — Main message body of the sync warning popup.
-- `SYNC.WARNING.DETAILS` (string) — Expandable detail text shown when the user clicks "More information" in the sync warning popup.
-- `SYNC.WARNING.DETAILS_LABEL` (string) — Label for the button that expands the detail text in the sync warning popup.
-- `SYNC.WARNING.LOGIN_LABEL` (string) — Label for the primary login button in the sync warning popup.
-- `SYNC.WARNING.DISMISS_LABEL` (string) — Label for the dismiss link in the sync warning popup.
+- `SYNC.WARNING.HEADING` (string, required) — Heading of the sync warning popup.
+- `SYNC.WARNING.TITLE` (string, required) — Main message body of the sync warning popup.
+- `SYNC.WARNING.DETAILS` (string, required) — Expandable detail text shown when the user clicks "More information" in the sync warning popup.
+- `SYNC.WARNING.DETAILS_LABEL` (string, required) — Label for the button that expands the detail text in the sync warning popup.
+- `SYNC.WARNING.LOGIN_LABEL` (string, required) — Label for the primary login button in the sync warning popup.
+- `SYNC.WARNING.DISMISS_LABEL` (string, required) — Label for the dismiss link in the sync warning popup.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^6.0.3",
+        "ajv": "^8.20.0",
         "terser": "^5.48.0",
         "vite": "^8.1.3"
       }
@@ -1482,6 +1483,23 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/anser": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
@@ -2270,6 +2288,23 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fb-dotslash": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/fb-dotslash/-/fb-dotslash-0.5.8.tgz",
@@ -2922,6 +2957,13 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -5367,6 +5409,16 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
       "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
   "scripts": {
     "start": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "validate:config-example": "node scripts/validateConfigExample.mjs",
+    "docs:generate": "node scripts/generateConfigDocs.mjs",
+    "docs:check": "node scripts/generateConfigDocs.mjs --check"
   },
   "browserslist": {
     "production": [
@@ -40,6 +43,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^6.0.3",
+    "ajv": "^8.20.0",
     "terser": "^5.48.0",
     "vite": "^8.1.3"
   },

--- a/scripts/generateConfigDocs.mjs
+++ b/scripts/generateConfigDocs.mjs
@@ -1,0 +1,95 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const schemaPath = path.join(__dirname, "..", "src", "configSchema.json");
+const outPath = path.join(__dirname, "..", "docs", "config_reference.md");
+
+/**
+ * Render a JSON-Schema type keyword as a short human-readable label.
+ * @param {object} propSchema
+ * @returns {string}
+ */
+function typeLabel(propSchema) {
+  if (propSchema.type === "array") {
+    const itemType = propSchema.items ? typeLabel(propSchema.items) : "any";
+    return `array of ${itemType}`;
+  }
+  return propSchema.type ?? "any";
+}
+
+/**
+ * Render a single property (and, recursively, its object/array-of-object
+ * children) as one or more Markdown bullets, using dotted key paths the
+ * same way the old hand-written README list did.
+ *
+ * @param {string} keyPath Dotted path so far, e.g. "PROGRAM.LIMIT".
+ * @param {object} propSchema The JSON Schema node for this property.
+ * @param {boolean} required Whether this key is in its parent's `required`.
+ * @param {string[]} lines Accumulator of Markdown lines.
+ */
+function renderProperty(keyPath, propSchema, required, lines) {
+  const parts = [`\`${keyPath}\` (${typeLabel(propSchema)}${required ? ", required" : ""})`];
+  if (propSchema.description) parts.push(propSchema.description);
+  if (propSchema.default !== undefined) {
+    parts.push(`Default: \`${JSON.stringify(propSchema.default)}\`.`);
+  }
+  lines.push(`- ${parts.join(" — ")}`);
+
+  if (propSchema.type === "object" && propSchema.properties) {
+    const childRequired = new Set(propSchema.required ?? []);
+    for (const [childKey, childSchema] of Object.entries(propSchema.properties)) {
+      renderProperty(`${keyPath}.${childKey}`, childSchema, childRequired.has(childKey), lines);
+    }
+  } else if (propSchema.type === "array" && propSchema.items?.type === "object" && propSchema.items.properties) {
+    for (const [childKey, childSchema] of Object.entries(propSchema.items.properties)) {
+      renderProperty(`${keyPath}[].${childKey}`, childSchema, false, lines);
+    }
+  }
+}
+
+/**
+ * Generate the full Markdown reference document from a JSON Schema object.
+ * @param {object} schema
+ * @returns {string}
+ */
+export function generateDocs(schema) {
+  const lines = [
+    "# ConClár configuration reference",
+    "",
+    "This document is generated from `src/configSchema.json` via `npm run docs:generate`. Do not edit it by hand — edit the schema instead and regenerate.",
+    "",
+    "Copy `src/config_example.json` to `src/config.json` and customise. See the [Getting Started](../README.md#getting-started) section of the README for details.",
+    "",
+  ];
+  const topRequired = new Set(schema.required ?? []);
+  for (const [key, propSchema] of Object.entries(schema.properties)) {
+    renderProperty(key, propSchema, topRequired.has(key), lines);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function main() {
+  const schema = JSON.parse(fs.readFileSync(schemaPath, "utf-8"));
+  const generated = generateDocs(schema);
+
+  if (process.argv.includes("--check")) {
+    const existing = fs.existsSync(outPath) ? fs.readFileSync(outPath, "utf-8") : "";
+    if (existing !== generated) {
+      console.error(
+        "docs/config_reference.md is out of date with src/configSchema.json.\n" +
+          "Run `npm run docs:generate` and commit the result."
+      );
+      process.exit(1);
+    }
+    console.log("docs/config_reference.md is up to date.");
+    return;
+  }
+
+  fs.writeFileSync(outPath, generated);
+  console.log("Wrote docs/config_reference.md");
+}
+
+main();

--- a/scripts/validateConfigExample.mjs
+++ b/scripts/validateConfigExample.mjs
@@ -1,0 +1,17 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { validateConfig } from "../src/validateConfig.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const configPath = path.join(__dirname, "..", "src", "config_example.json");
+
+const configData = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+
+try {
+  validateConfig(configData);
+  console.log("src/config_example.json is valid.");
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}

--- a/src/ProgramData.js
+++ b/src/ProgramData.js
@@ -353,7 +353,7 @@ export class ProgramData {
    */
   static processData(progData, pplData) {
     let program = this.processProgramData(progData);
-    if (configData.TAGS.FORMAT_AS_TAG) program = this.reformatAsTag(program);
+    if (configData.TAGS?.FORMAT_AS_TAG) program = this.reformatAsTag(program);
     if (
       configData.LINKS &&
       configData.LINKS.filter((link) => link.TAG.length > 0).length > 0
@@ -362,8 +362,8 @@ export class ProgramData {
     const people = this.processPeopleData(pplData);
     this.addProgramParticipantDetails(program, people);
     const locations = this.processLocations(program);
-    const tags = this.processTags(program, configData.TAGS);
-    const personTags = this.processTags(people, configData.PEOPLE.TAGS);
+    const tags = this.processTags(program, configData.TAGS ?? {});
+    const personTags = this.processTags(people, configData.PEOPLE?.TAGS ?? {});
     LocalTime.checkTimeZonesDiffer(program);
 
     //setLoadingMessage("Processing Complete... Rendering...")

--- a/src/components/FilterableProgram.jsx
+++ b/src/components/FilterableProgram.jsx
@@ -168,7 +168,7 @@ const FilterableProgram = () => {
     if (LocalTime.isDuringCon(program) && !showPastItems) {
       filtered = LocalTime.filterPastItems(filtered);
     }
-    if (!configData.HIDE_BEFORE.HIDE && hideBefore) {
+    if (!configData.HIDE_BEFORE?.HIDE && hideBefore) {
       if (
         "days" in selTags &&
         Array.isArray(selTags.days) &&
@@ -258,19 +258,7 @@ const FilterableProgram = () => {
     );
 
   // create list of options for hide before time drop-down.
-  const hideBeforeOptions = [
-    <option value="" key="0">
-      {configData.HIDE_BEFORE.PLACEHOLDER}
-    </option>,
-  ];
-  for (const time of configData.HIDE_BEFORE.TIMES) {
-    hideBeforeOptions.push(
-      <option value={time.TIME} key={time.TIME}>
-        {show12HourTime ? time.LABEL_12H : time.LABEL_24H}
-      </option>
-    );
-  }
-  const hideBeforeSelect = configData.HIDE_BEFORE.HIDE ? (
+  const hideBeforeSelect = !configData.HIDE_BEFORE || configData.HIDE_BEFORE.HIDE ? (
     <></>
   ) : (
     <div className="filter-hide-before">
@@ -284,7 +272,14 @@ const FilterableProgram = () => {
           setHideBefore(e.target.value);
         }}
       >
-        {hideBeforeOptions}
+        <option value="" key="0">
+          {configData.HIDE_BEFORE.PLACEHOLDER}
+        </option>
+        {(configData.HIDE_BEFORE.TIMES ?? []).map((time) => (
+          <option value={time.TIME} key={time.TIME}>
+            {show12HourTime ? time.LABEL_12H : time.LABEL_24H}
+          </option>
+        ))}
       </select>
     </div>
   );
@@ -298,7 +293,7 @@ const FilterableProgram = () => {
               placeholder="Select locations"
               options={buildLocationOptions(locations, configData)}
               isMulti
-              isSearchable={configData.LOCATIONS.SEARCHABLE}
+              isSearchable={configData.LOCATIONS?.SEARCHABLE}
               value={selLoc}
               onChange={(value) => {
                 resetDisplayLimit();
@@ -319,7 +314,7 @@ const FilterableProgram = () => {
             tags={tags}
             selTags={selTags}
             setSelTags={setSelTags}
-            tagConfig={configData.TAGS}
+            tagConfig={configData.TAGS ?? {}}
             resetLimit={resetDisplayLimit}
           />
           {hideBeforeSelect}
@@ -349,10 +344,10 @@ const FilterableProgram = () => {
             <div className="filter-total">{totalMessage}</div>
             <div className="filter-expand">
               <button disabled={allExpanded} onClick={expandAll}>
-                {configData.EXPAND.EXPAND_ALL_LABEL}
+                {configData.EXPAND?.EXPAND_ALL_LABEL ?? "Expand All"}
               </button>
               <button disabled={noneExpanded} onClick={collapseAll}>
-                {configData.EXPAND.COLLAPSE_ALL_LABEL}
+                {configData.EXPAND?.COLLAPSE_ALL_LABEL ?? "Collapse All"}
               </button>
             </div>
           </div>

--- a/src/components/HelpText.jsx
+++ b/src/components/HelpText.jsx
@@ -15,6 +15,9 @@ const HelpText = () => {
   if (selector in helpTextDismissed && helpTextDismissed[selector]) {
     return <></>;
   }
+  if (!configData.HELP_TEXT) {
+    return <></>;
+  }
   const text = configData.HELP_TEXT[selector];
   return (
     <div className="help-text">

--- a/src/components/MySchedule.jsx
+++ b/src/components/MySchedule.jsx
@@ -48,10 +48,10 @@ const MySchedule = () => {
         <div className="stack">
           <div className="filter-expand">
             <button disabled={allSelectedExpanded} onClick={expandSelected}>
-              {configData.EXPAND.EXPAND_ALL_LABEL}
+              {configData.EXPAND?.EXPAND_ALL_LABEL ?? "Expand All"}
             </button>
             <button disabled={noneExpanded} onClick={collapseSelected}>
-              {configData.EXPAND.COLLAPSE_ALL_LABEL}
+              {configData.EXPAND?.COLLAPSE_ALL_LABEL ?? "Collapse All"}
             </button>
           </div>
         </div>

--- a/src/components/Participant.jsx
+++ b/src/components/Participant.jsx
@@ -21,7 +21,7 @@ const Participant = ({ person, thumbnails = true, moderator }) => {
         );
       }
       if (
-        configData.PEOPLE.THUMBNAILS &&
+        configData.PEOPLE?.THUMBNAILS &&
         configData.PEOPLE.THUMBNAILS.SHOW_THUMBNAILS &&
         configData.PEOPLE.THUMBNAILS.DEFAULT_IMAGE
       ) {
@@ -47,7 +47,7 @@ const Participant = ({ person, thumbnails = true, moderator }) => {
         <span>
           {person.name}{" "}
           <span className="moderator">
-            {configData.PEOPLE.MODERATORS.MODERATOR_LABEL}
+            {configData.PEOPLE?.MODERATORS?.MODERATOR_LABEL}
           </span>
         </span>
       );

--- a/src/components/People.jsx
+++ b/src/components/People.jsx
@@ -58,17 +58,17 @@ const People = () => {
       key={person.id}
       person={person}
       thumbnails={
-        configData.PEOPLE.THUMBNAILS.SHOW_THUMBNAILS && showThumbnails
+        configData.PEOPLE?.THUMBNAILS?.SHOW_THUMBNAILS && showThumbnails
       }
     />
   ));
 
   const thumbnailCheckboxLabel =
-    configData.PEOPLE.THUMBNAILS.SHOW_THUMBNAILS ===
-    configData.PEOPLE.THUMBNAILS.SHOW_CHECKBOX
-      ? configData.PEOPLE.THUMBNAILS.CHECKBOX_LABEL
-      : configData.USELESS_CHECKBOX.CHECKBOX_LABEL;
-  const thumbnailsCheckbox = configData.PEOPLE.THUMBNAILS.SHOW_CHECKBOX ? (
+    configData.PEOPLE?.THUMBNAILS?.SHOW_THUMBNAILS ===
+    configData.PEOPLE?.THUMBNAILS?.SHOW_CHECKBOX
+      ? configData.PEOPLE?.THUMBNAILS?.CHECKBOX_LABEL
+      : configData.USELESS_CHECKBOX?.CHECKBOX_LABEL;
+  const thumbnailsCheckbox = configData.PEOPLE?.THUMBNAILS?.SHOW_CHECKBOX ? (
     <Switch
       id="thumbnails"
       label={thumbnailCheckboxLabel}
@@ -78,17 +78,17 @@ const People = () => {
     ""
   );
 
-  const sortCheckbox = configData.PEOPLE.SORT.SHOW_CHECKBOX ? (
+  const sortCheckbox = configData.PEOPLE?.SORT?.SHOW_CHECKBOX ? (
     <Switch
       id="sort_people"
-      label={configData.PEOPLE.SORT.CHECKBOX_LABEL}
+      label={configData.PEOPLE?.SORT?.CHECKBOX_LABEL}
       checked={sortByFullName}
       onChange={setSortByFullName} />
   ) : (
     ""
   );
 
-  const searchInput = configData.PEOPLE.SEARCH.SHOW_SEARCH ? (
+  const searchInput = configData.PEOPLE?.SEARCH?.SHOW_SEARCH ? (
     <div className="people-search">
       <label htmlFor="people-search">Search people</label>
       <input
@@ -96,7 +96,7 @@ const People = () => {
         type="search"
         value={search}
         onChange={(e) => setSearch(e.target.value)}
-        placeholder={configData.PEOPLE.SEARCH.SEARCH_LABEL}
+        placeholder={configData.PEOPLE?.SEARCH?.SEARCH_LABEL}
       />
     </div>
   ) : (
@@ -113,7 +113,7 @@ const People = () => {
             tags={personTags}
             selTags={selTags}
             setSelTags={setSelTags}
-            tagConfig={configData.PEOPLE.TAGS}
+            tagConfig={configData.PEOPLE?.TAGS ?? {}}
           />
           {searchInput}
         </div>

--- a/src/components/Person.jsx
+++ b/src/components/Person.jsx
@@ -24,7 +24,7 @@ const Person = () => {
   const img = person.img ? <img src={person.img} alt={person.name} /> : "";
   // Sanitize the bio to remove dangerous HTML, using options from config.
   const safeBio = person.bio
-    ? DOMPurify.sanitize(person.bio, configData.PEOPLE.BIO.PURIFY_OPTIONS)
+    ? DOMPurify.sanitize(person.bio, configData.PEOPLE?.BIO?.PURIFY_OPTIONS)
     : "";
   const filteredProgram = program.filter((item) => {
     if (item.people) {
@@ -51,7 +51,7 @@ const Person = () => {
         <button className="person-back-button" onClick={() => navigate(-1)}>
           <MdOutlineArrowBackIos />
         </button>{" "}
-        <span className="person-title">{configData.PEOPLE.PERSON_HEADER}</span>
+        <span className="person-title">{configData.PEOPLE?.PERSON_HEADER}</span>
         {person.name}
       </h2>
       {getPersonTags(person)}

--- a/src/components/ProgramItem.jsx
+++ b/src/components/ProgramItem.jsx
@@ -90,7 +90,7 @@ const ProgramItem = ({ item, forceExpanded = false, now }) => {
     ) : null;
 
   const permaLink =
-    configData.PERMALINK.SHOW_PERMALINK && configData.INTERACTIVE ? (
+    configData.PERMALINK?.SHOW_PERMALINK && configData.INTERACTIVE ? (
       <div className="item-permalink">
         <Link
           to={"/id/" + item.id}
@@ -105,7 +105,7 @@ const ProgramItem = ({ item, forceExpanded = false, now }) => {
 
   const tags = [];
   const itemTags = item.tags.filter(
-    (tag) => !configData.TAGS.DONTLIST.includes(tag.category)
+    (tag) => !configData.TAGS?.DONTLIST?.includes(tag.category)
   );
 
   for (const tag of itemTags) {
@@ -126,7 +126,7 @@ const ProgramItem = ({ item, forceExpanded = false, now }) => {
   }
   const safeDesc = DOMPurify.sanitize(
     item.desc,
-    configData.ITEM_DESCRIPTION.PURIFY_OPTIONS
+    configData.ITEM_DESCRIPTION?.PURIFY_OPTIONS
   );
 
   const links = [];
@@ -148,7 +148,7 @@ const ProgramItem = ({ item, forceExpanded = false, now }) => {
     });
   }
 
-  if ("MAPPING" in configData.LOCATIONS) {
+  if (configData.LOCATIONS && "MAPPING" in configData.LOCATIONS) {
     for (const location of configData.LOCATIONS.MAPPING) {
       if (item.loc.toString() === location.KEY) {
         links.push(
@@ -165,7 +165,7 @@ const ProgramItem = ({ item, forceExpanded = false, now }) => {
   }
 
   const duration =
-    configData.DURATION.SHOW_DURATION && item.mins ? (
+    configData.DURATION?.SHOW_DURATION && item.mins ? (
       <div className="item-duration">
         {configData.DURATION.DURATION_LABEL.replace("@mins", item.mins)}
       </div>
@@ -191,15 +191,16 @@ const ProgramItem = ({ item, forceExpanded = false, now }) => {
       : null;
   let startTime;
   if (localTime) {
-    startTime = configData.START_TIME.START_TIME_WITH_LOCAL_LABEL.replace(
-      "@local_time",
-      localTime
-    ).replace("@con_time", conTime);
+    startTime = (
+      configData.START_TIME?.START_TIME_WITH_LOCAL_LABEL ??
+      "Starts: @con_time con time, @local_time local time"
+    )
+      .replace("@local_time", localTime)
+      .replace("@con_time", conTime);
   } else {
-    startTime = configData.START_TIME.START_TIME_LABEL.replace(
-      "@con_time",
-      conTime
-    );
+    startTime = (
+      configData.START_TIME?.START_TIME_LABEL ?? "Starts: @con_time"
+    ).replace("@con_time", conTime);
   }
 
   const [ref, bounds] = useMeasure();
@@ -220,8 +221,8 @@ const ProgramItem = ({ item, forceExpanded = false, now }) => {
     config: {
       tension: 300,
       friction: 15,
-      clamp: true, 
-      ...configData.EXPAND.SPRING_CONFIG
+      clamp: true,
+      ...configData.EXPAND?.SPRING_CONFIG
     },
     onRest: () => {
       if (!showExpanded) setDetailsVisible(false);

--- a/src/components/ProgramList.jsx
+++ b/src/components/ProgramList.jsx
@@ -64,17 +64,20 @@ const ProgramList = ({ program, forceExpanded = false }) => {
       now={now}
     />
   );
-  const conventionTime = (
+  const conventionTime = configData.CONVENTION_TIME?.NOTICE ? (
     <div className="time-convention-message" aria-hidden="true">
       {configData.CONVENTION_TIME.NOTICE.replace(
         "@timezone",
         configData.TIMEZONE
       )}
     </div>
+  ) : (
+    ""
   );
   const localTime =
-    showLocalTime === "always" ||
-    (showLocalTime === "differs" && LocalTime.timezonesDiffer) ? (
+    (showLocalTime === "always" ||
+      (showLocalTime === "differs" && LocalTime.timezonesDiffer)) &&
+    configData.LOCAL_TIME?.NOTICE ? (
       <div className="time-local-message">
         {configData.LOCAL_TIME.NOTICE.replace(
           "@timezone",

--- a/src/components/ResetButton.jsx
+++ b/src/components/ResetButton.jsx
@@ -3,7 +3,7 @@ import configData from "../config.json";
 const ResetButton = ({ isFiltered, resetFilters }) => {
   const button = isFiltered ? (
     <button className="reset-button" onClick={() => resetFilters()}>
-      {configData.FILTER.RESET.LABEL}
+      {configData.FILTER?.RESET?.LABEL ?? "Reset filters"}
     </button>
   ) : (
     ""

--- a/src/components/ShowPastItems.jsx
+++ b/src/components/ShowPastItems.jsx
@@ -10,10 +10,10 @@ const ShowPastItems = () => {
     (actions) => actions.setShowPastItems
   );
   return LocalTime.isDuringCon(program) &&
-    configData.SHOW_PAST_ITEMS.SHOW_CHECKBOX ? (
+    configData.SHOW_PAST_ITEMS?.SHOW_CHECKBOX ? (
     <Switch
       id={LocalTime.pastItemsClass}
-      label={configData.SHOW_PAST_ITEMS.CHECKBOX_LABEL}
+      label={configData.SHOW_PAST_ITEMS?.CHECKBOX_LABEL}
       checked={showPastItems}
       onChange={setShowPastItems} />
   ) : (

--- a/src/components/TagSelectors.jsx
+++ b/src/components/TagSelectors.jsx
@@ -8,9 +8,9 @@ const TagSelectors = ({ tags, selTags, setSelTags, tagConfig, resetLimit }) => {
    */
   function findTagData(tag) {
     // Check for day tag.
-    if (tag === "days" && tagConfig.DAY_TAG.GENERATE)
+    if (tag === "days" && tagConfig.DAY_TAG?.GENERATE)
       return tagConfig.DAY_TAG;
-    const tagData = tagConfig.SEPARATE.find(
+    const tagData = tagConfig.SEPARATE?.find(
       (item) => item.PREFIX === tag
     );
     if (tagData !== undefined) return tagData;

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -1,0 +1,723 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/lostcarpark/conclar/config-schema.json",
+  "title": "ConClár configuration",
+  "description": "Schema for src/config.json. Copy src/config_example.json to src/config.json and customise. This schema is the source of truth for docs/config_reference.md (generated via `npm run docs:generate`) and is validated automatically on `npm start`/`npm run build` and, against src/config_example.json, in CI.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "APP_ID",
+    "APP_TITLE",
+    "TIMEZONE",
+    "TIMEZONECODE",
+    "NAVIGATION",
+    "HEADER",
+    "PROGRAM",
+    "SETTINGS",
+    "FOOTER",
+    "APPLICATION",
+    "INFORMATION",
+    "DEBUG_MODE",
+    "TIMER"
+  ],
+  "properties": {
+    "APP_ID": {
+      "type": "string",
+      "description": "A unique id to distinguish between instances of multi-year conventions."
+    },
+    "APP_TITLE": {
+      "type": "string",
+      "description": "The title to appear at the top of the webpage, and in the browser window title."
+    },
+    "PROGRAM_DATA_URL": {
+      "type": "string",
+      "description": "Legacy config for the address of the file containing programme data, in the bare-array format. If the same as PEOPLE_DATA_URL, both will be read from one file, but programme data must come before people data. Mutually exclusive with DATA_URLS; exactly one of DATA_URLS or the PROGRAM_DATA_URL/PEOPLE_DATA_URL pair must be given."
+    },
+    "PEOPLE_DATA_URL": {
+      "type": "string",
+      "description": "Legacy config for the address of the file containing people data, in the bare-array format. If the same as PROGRAM_DATA_URL, both will be read from one file, but programme data must come before people data. Mutually exclusive with DATA_URLS; exactly one of DATA_URLS or the PROGRAM_DATA_URL/PEOPLE_DATA_URL pair must be given."
+    },
+    "DATA_URLS": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "The address(es) of the schedule/people data files, in the self-describing schemaVersion object format. Specify COMBINED for both from one file, or SCHEDULE and PEOPLE together for separate files. Specifying both COMBINED and SCHEDULE/PEOPLE together, or only one of SCHEDULE/PEOPLE, is a config error, enforced at validation time rather than by this schema. Mutually exclusive with PROGRAM_DATA_URL/PEOPLE_DATA_URL; exactly one of DATA_URLS or that legacy pair must be given. See docs/conclar_file_specs.md for the fetched file format.",
+      "properties": {
+        "COMBINED": {
+          "type": "string",
+          "description": "Address of a single file containing both schedule and people data. Mutually exclusive with SCHEDULE/PEOPLE."
+        },
+        "SCHEDULE": {
+          "type": "string",
+          "description": "Address of the file containing schedule data. Must be given together with PEOPLE."
+        },
+        "PEOPLE": {
+          "type": "string",
+          "description": "Address of the file containing people data. Must be given together with SCHEDULE."
+        }
+      }
+    },
+    "FETCH_OPTIONS": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Options to pass when fetching data. See JavaScript fetch() documentation for the full set of available values; any option not listed below is still accepted and passed through.",
+      "properties": {
+        "cache": {
+          "type": "string",
+          "description": "Should generally be set to \"reload\" so back-end program updates will be read rather than served from the browser cache."
+        },
+        "credentials": {
+          "type": "string",
+          "description": "Set to \"omit\" if the data source is not using a certificate from a recognised authority, e.g. a self-signed cert."
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Headers sent in the fetch. Origin may be required for Cross Origin Resource Sharing (CORS)."
+        }
+      }
+    },
+    "FETCH_OPTIONS_FIRST": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Same as FETCH_OPTIONS, but used only for the first fetch of data (e.g. to allow different credentials/cache behaviour on initial load).",
+      "properties": {
+        "cache": { "type": "string" },
+        "credentials": { "type": "string" },
+        "headers": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    },
+    "TIMEZONE": {
+      "type": "string",
+      "description": "The name of the timezone where your convention takes place (e.g. \"Europe/Dublin\"). Viewers outside convention timezone will see times in convention time, and their local time below it."
+    },
+    "TIMEZONECODE": {
+      "type": "string",
+      "description": "The short code for the convention timezone (e.g. \"IST\"). Set to an empty string to get the browser's code for the timezone (not recommended, as it may not select the most elegant short code). Must be present (may be empty) - the app reads it unconditionally when displaying local time."
+    },
+    "INTERACTIVE": {
+      "type": "boolean",
+      "description": "Set to false to get a non-interactive, expanded view of the schedule. The info page is also included, but not the participant list, individual participant pages, or individual item pages (regardless of the PERMALINK.SHOW_PERMALINK setting)."
+    },
+    "HEADER": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Add an optional image to the header of the pages.",
+      "properties": {
+        "IMG_SRC": {
+          "type": "string",
+          "description": "Set to the image filename to display. May be a file in the public directory. Leave blank for no image."
+        },
+        "IMG_ALT_TEXT": {
+          "type": "string",
+          "description": "Set to the alt text that should display for the image."
+        },
+        "LINEFEED_AFTER_URL": {
+          "type": "boolean",
+          "description": "If true, place a line feed after the image."
+        }
+      }
+    },
+    "NAVIGATION": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Each value in this section sets the label that will appear on main navigation of the site. Useful for switching between different international spellings of \"programme\".",
+      "properties": {
+        "PROGRAM": { "type": "string", "description": "Label for program/programme menu." },
+        "PEOPLE": { "type": "string", "description": "Label for people menu." },
+        "MYSCHEDULE": { "type": "string", "description": "Label for user's personal schedule." },
+        "INFO": { "type": "string", "description": "Label for the Information menu link." },
+        "SETTINGS": { "type": "string", "description": "Label for the Settings menu link." },
+        "EXTRA": {
+          "type": "array",
+          "description": "An array of extra menu links. To have no extra links, set to an empty array or omit EXTRA entirely.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "LABEL": { "type": "string", "description": "Text of the extra navigation link." },
+              "URL": { "type": "string", "description": "URL the extra navigation link points to." },
+              "ICON_NAME": {
+                "type": "string",
+                "description": "Name of a built-in icon to show before the label, e.g. \"Home\". Available names: Discord, Envelope, Facebook, Globe, Home, Instagram, Map, Mastodon, PaperPlane, Question, Sign, Ticket, Twitter, Youtube. (To add more, see iconsByName in src/components/NavIcon.js.) If both ICON_NAME and ICON_URL are given, ICON_NAME takes precedence."
+              },
+              "ICON_URL": {
+                "type": "string",
+                "description": "URL of an image to use as the icon instead of a built-in one. Used only if ICON_NAME isn't given."
+              }
+            }
+          }
+        }
+      }
+    },
+    "HELP_TEXT": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Text shown to new visitors to introduce the site's features.",
+      "properties": {
+        "WELCOME": { "type": "string", "description": "Text to display to new visitors who haven't selected any programme items." },
+        "SHARING": { "type": "string", "description": "Text to display when user has selected items, informing them of sharing options." },
+        "CLOSE_ARIA_LABEL": { "type": "string", "description": "Label to describe dismiss button." }
+      }
+    },
+    "LOCATIONS": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Configures the location filter and optional links to maps for each location.",
+      "properties": {
+        "SEARCHABLE": { "type": "boolean", "description": "Whether the location list can be searched by typing. (Searching can be inconvenient on touch screens.)" },
+        "LABEL": { "type": "string", "description": "Label to show on map links." },
+        "MAPPING": {
+          "type": "array",
+          "description": "Array of locations, with links to show on map.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "KEY": { "type": "string", "description": "Room name, matching the location name used in the programme data." },
+              "MAP_URL": { "type": "string", "description": "Link to a map for this location." }
+            }
+          }
+        }
+      }
+    },
+    "VENUES": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Groups locations by venue, for conventions spanning more than one building. If omitted, the locations drop-down is a flat, ungrouped list.",
+      "properties": {
+        "ALL_LABEL": {
+          "type": "string",
+          "description": "Label template for the \"select this whole venue\" option shown at the top of each venue's group in the locations drop-down. @venue is replaced with the venue name. Defaults to \"All @venue\"."
+        },
+        "UNGROUPED_LABEL": {
+          "type": "string",
+          "description": "Label for the group heading shown above locations that aren't listed under any venue. Defaults to \"Other\"."
+        },
+        "MAPPING": {
+          "type": "array",
+          "description": "Array of venues. Venues are listed in the locations drop-down in the order given here. A location may only belong to one venue; locations not listed under any venue are shown grouped under UNGROUPED_LABEL, below the venue groups. Selecting a venue's \"All <venue>\" option shows every programme item in any of that venue's locations. Venue names must be unique and a location may not be assigned to more than one venue - enforced at validation time, not by this schema.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "NAME": { "type": "string", "description": "Venue name, shown in the locations drop-down." },
+              "LOCATIONS": {
+                "type": "array",
+                "description": "Location names (matching LOCATIONS.MAPPING keys / programme data location names) that belong to this venue.",
+                "items": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "APPLICATION": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "General application-wide settings.",
+      "properties": {
+        "LOADING": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "MESSAGE": { "type": "string", "description": "Message to display while loading." }
+          }
+        }
+      }
+    },
+    "PROGRAM": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Settings for the main programme list, My Schedule, and shared-items pages.",
+      "properties": {
+        "LIMIT": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Controls the \"maximum items displayed\" drop-down on the programme page.",
+          "properties": {
+            "SHOW": { "type": "boolean", "description": "If true, \"limit number of items\" drop-down will be displayed." },
+            "LABEL": { "type": "string", "description": "Label for limit drop-down." },
+            "OPTIONS": {
+              "type": "array",
+              "description": "Options for the limit drop-down.",
+              "items": { "type": "integer" }
+            },
+            "ALL_LABEL": { "type": "string", "description": "Label to show for the \"All\" entry." },
+            "DEFAULT": { "type": "integer", "description": "Default value for the limit drop-down." },
+            "SHOW_MORE": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "LABEL": { "type": "string", "description": "Label for the \"Show more\" button." },
+                "NO_MORE": { "type": "string", "description": "Message to display when no more items are available." },
+                "NUM_EXTRA": { "type": "integer", "description": "Number of items to add when \"Show more\" is pressed." }
+              }
+            }
+          }
+        },
+        "SEARCH": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "SEARCH_LABEL": { "type": "string", "description": "Placeholder for the programme search box." }
+          }
+        },
+        "MY_SCHEDULE": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Settings for the My Schedule page.",
+          "properties": {
+            "TITLE": { "type": "string", "description": "Title of My Schedule page." },
+            "EMPTY": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "TEXT": { "type": "string", "description": "Text to display on My Schedule when no programme items are selected." }
+              }
+            },
+            "INTRO": { "type": "string", "description": "Introduction text for the My Schedule page." },
+            "SHARE": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Settings for the QR code / link sharing section of My Schedule.",
+              "properties": {
+                "LABEL": { "type": "string", "description": "Heading for the shared link section on My Schedule." },
+                "DESCRIPTION": { "type": "string", "description": "Descriptive message for the link sharing section." },
+                "LINK_LABEL": { "type": "string", "description": "Label for the link when there is a single sharing link on the page." },
+                "MAX_LENGTH": { "type": "integer", "description": "Maximum number of characters in each shareable link." },
+                "MULTIPLE_DESCRIPTION": { "type": "string", "description": "Description to display when multiple links are shown." },
+                "MULTIPLE_LINK_LABEL": { "type": "string", "description": "Label for a link when multiple links are shown. @number is replaced by the link's number." }
+              }
+            }
+          }
+        },
+        "SHARED": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Settings for the page showing programme items shared via a link.",
+          "properties": {
+            "TITLE": { "type": "string", "description": "Title of the Shared Programme Items page." },
+            "DESCRIPTION": { "type": "string", "description": "Descriptive text for the page showing shared items." },
+            "BUTTON_LABEL": { "type": "string", "description": "Text for the \"Add all to My Schedule\" button." }
+          }
+        }
+      }
+    },
+    "TAGS": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Settings for the tag filter on the programme page.",
+      "properties": {
+        "PLACEHOLDER": { "type": "string", "description": "The placeholder when selecting tags (unless separated)." },
+        "SEARCHABLE": { "type": "boolean", "description": "Whether the tag list can be searched by typing (unless separated)." },
+        "HIDE": { "type": "boolean", "description": "If true, hide the tags drop-down. Tags are still displayed on items." },
+        "SEPARATE": {
+          "type": "array",
+          "description": "An array of tag prefixes to separate into individual drop-downs.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "PREFIX": { "type": "string", "description": "Tag prefix to separate out into its own drop-down, e.g. \"type\"." },
+              "PLACEHOLDER": { "type": "string", "description": "Placeholder for this drop-down." },
+              "SEARCHABLE": { "type": "boolean", "description": "Whether this drop-down can be searched by typing." },
+              "HIDE": { "type": "boolean", "description": "If true, hide this drop-down. Tags are still displayed on items." }
+            }
+          }
+        },
+        "FORMAT_AS_TAG": { "type": "boolean", "description": "If set to true, turns Grenadine item format into a KonOpas-style \"type\" tag." },
+        "DAY_TAG": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Settings for auto-generated per-day tags.",
+          "properties": {
+            "GENERATE": { "type": "boolean", "description": "If set to true, will generate tags for each day of the convention." },
+            "DAYS": {
+              "type": "object",
+              "description": "Key/value pairs mapping ISO weekday numbers (1 = Monday .. 7 = Sunday) to day names.",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[1-7]$": { "type": "string" }
+              }
+            },
+            "PLACEHOLDER": { "type": "string", "description": "The placeholder for the \"day\" tags drop-down." },
+            "SEARCHABLE": { "type": "boolean", "description": "Whether the day tag list can be searched by typing." },
+            "HIDE": { "type": "boolean", "description": "If true, hide the day tags drop-down. Day tags are still shown on items if GENERATE is true." }
+          }
+        },
+        "DONTLIST": {
+          "type": "array",
+          "description": "An array of tags not to list in the drop-downs and programme item tag lists.",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "HIDE_BEFORE": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Settings for the \"hide items before this time\" filter.",
+      "properties": {
+        "HIDE": { "type": "boolean", "description": "If true, hide the \"hide before\" dropdown. If false, show a dropdown containing times to hide items before." },
+        "PLACEHOLDER": { "type": "string", "description": "Placeholder text for the hide-before drop-down." },
+        "TIMES": {
+          "type": "array",
+          "description": "Array of times to list in the hide-before drop-down. Times should be in convention timezone.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "TIME": { "type": "string", "description": "Time in hh:mm:ss format." },
+              "LABEL_24H": { "type": "string", "description": "24-hour format label for this time." },
+              "LABEL_12H": { "type": "string", "description": "12-hour format label for this time." }
+            }
+          }
+        }
+      }
+    },
+    "FILTER": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "RESET": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "LABEL": { "type": "string", "description": "The label for the \"Reset filters\" button." }
+          }
+        }
+      }
+    },
+    "PERMALINK": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "SHOW_PERMALINK": { "type": "boolean", "description": "If true, display a \"permalink\" icon when each program item is expanded." },
+        "PERMALINK_TITLE": { "type": "string", "description": "\"Title\" text displayed when the mouse is hovered over the permalink icon." }
+      }
+    },
+    "CALENDARLINK": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "SHOW": { "type": "boolean", "description": "If true, display a calendar download icon when each program item is expanded." },
+        "TITLE": { "type": "string", "description": "\"Title\" text displayed when the mouse is hovered over the calendar download icon." }
+      }
+    },
+    "EXPAND": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "EXPAND_ALL_LABEL": { "type": "string", "description": "Label text for the Expand All button." },
+        "COLLAPSE_ALL_LABEL": { "type": "string", "description": "Label for the Collapse All button." },
+        "SPRING_CONFIG": {
+          "type": "object",
+          "description": "Config for the 'spring' animation used when expanding items. May be a simple duration, e.g. { \"duration\": 100 } to expand in 100ms, or can configure more dynamic spring effects, e.g. { \"mass\": 1, \"tension\": 1000, \"friction\": 30 }. Full list of options in the react-spring documentation (https://react-spring.io/common/configs).",
+          "additionalProperties": { "type": "number" }
+        }
+      }
+    },
+    "ITEM_DESCRIPTION": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "PURIFY_OPTIONS": {
+          "type": "object",
+          "description": "Additional options passed to DOMPurify when processing item descriptions. For the available options, see the DOMPurify documentation (https://github.com/cure53/DOMPurify#can-i-configure-dompurify).",
+          "additionalProperties": true,
+          "properties": {
+            "FORBID_ATTR": { "type": "array", "items": { "type": "string" } }
+          }
+        }
+      }
+    },
+    "LINKS": {
+      "type": "array",
+      "description": "An array of link types expected in the program data.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "NAME": { "type": "string", "description": "The name of the link as it appears in the links object in the program data." },
+          "TEXT": { "type": "string", "description": "The text that should appear on this link in ConClár." },
+          "TAG": { "type": "string", "description": "An optional tag to add to every program item which includes a matching link. If using prefixed tags, include the prefix, e.g. \"type:Workshop\"." },
+          "WHEN": {
+            "type": "array",
+            "description": "An optional array listing times when the link will be visible. Multiple values may be given, e.g. [\"before\", \"during\"], meaning the link is visible prior to the item and while it is happening, but disappears when it finishes. If omitted, the link is always visible.",
+            "items": { "type": "string", "enum": ["before", "during", "after"] }
+          }
+        }
+      }
+    },
+    "CONVENTION_TIME": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "NOTICE": {
+          "type": "string",
+          "description": "Notice explaining that displayed times are convention time. @timezone is replaced with the convention timezone."
+        }
+      }
+    },
+    "LOCAL_TIME": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "CHECKBOX_LABEL": { "type": "string", "description": "Label for the \"Show Local Time\" checkbox." },
+        "NOTICE": { "type": "string", "description": "Notice telling users how local time is displayed. @timezone is replaced with the convention timezone." },
+        "PREV_DAY": { "type": "string", "description": "Label appended to local time if local time is before the start of the advertised day." },
+        "NEXT_DAY": { "type": "string", "description": "Label appended to local time if local time is after the end of the advertised day." },
+        "FAILURE": { "type": "string", "description": "Local time depends on string conversions, and could fail in some circumstances. Message to display if unable to convert." }
+      }
+    },
+    "TIME_FORMAT": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "DEFAULT_12HR": { "type": "boolean", "description": "Set to true if you want time displayed in 12-hour format by default." },
+        "SHOW_CHECKBOX": { "type": "boolean", "description": "If set to false, users will not be given the option to change between 12 and 24 hour time." },
+        "CHECKBOX_LABEL": { "type": "string", "description": "Label for the 12-hour time checkbox." },
+        "AM": { "type": "string", "description": "Label for AM times." },
+        "PM": { "type": "string", "description": "Label for PM times." }
+      }
+    },
+    "DURATION": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "SHOW_DURATION": { "type": "boolean", "description": "If true, minutes from program data will be displayed." },
+        "DURATION_LABEL": { "type": "string", "description": "Format for duration. @mins is replaced by the number of minutes. Do not translate @mins." }
+      }
+    },
+    "START_TIME": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "START_TIME_LABEL": { "type": "string", "description": "Format for start time with just convention time, read by screen readers. @con_time is replaced by the start time. Do not translate @con_time." },
+        "START_TIME_WITH_LOCAL_LABEL": { "type": "string", "description": "Format for start time with both convention and local time, read by screen readers. @con_time and @local_time are replaced by the start times. Do not translate @con_time or @local_time." }
+      }
+    },
+    "SHOW_PAST_ITEMS": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "SHOW_CHECKBOX": { "type": "boolean", "description": "Set to true to show the \"show past items\" option during the convention; otherwise past programme items are shown by default." },
+        "CHECKBOX_LABEL": { "type": "string", "description": "Label for the show-past-items checkbox." },
+        "ADJUST_MINUTES": { "type": "number", "description": "Some wiggle room (in minutes) in order not to hide past items immediately as they start." },
+        "FROM_START": { "type": "boolean", "description": "If true, adjust from the item's start time rather than its end time when deciding whether it's \"past\"." }
+      }
+    },
+    "PEOPLE": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Settings for the people list and individual participant pages.",
+      "properties": {
+        "MODERATORS": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "MODERATOR_LABEL": { "type": "string", "description": "Label appended to a participant's name when they are the moderator of an item." }
+          }
+        },
+        "THUMBNAILS": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "SHOW_THUMBNAILS": { "type": "boolean", "description": "Set to false to not show member thumbnails (useful to remove spurious controls if pictures aren't in the data file)." },
+            "SHOW_CHECKBOX": { "type": "boolean", "description": "Set to false to hide the \"Show thumbnails\" checkbox." },
+            "CHECKBOX_LABEL": { "type": "string", "description": "Label for the \"Show thumbnails\" checkbox." },
+            "DEFAULT_IMAGE": { "type": "string", "description": "Default thumbnail for participants with no photo. Can be a filename of an image in the public directory, or an external URL. Leave blank for no default thumbnail." }
+          }
+        },
+        "SORT": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "SHOW_CHECKBOX": { "type": "boolean", "description": "Set to false to hide the \"Sort by full name\" checkbox. Useful if your data only contains \"name for publications\"." },
+            "CHECKBOX_LABEL": { "type": "string", "description": "Label for the \"Sort by full name\" checkbox." }
+          }
+        },
+        "TAGS": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Settings for the tag filter on the people page. Same shape as the top-level TAGS section, but without DAY_TAG/FORMAT_AS_TAG/DONTLIST.",
+          "properties": {
+            "PLACEHOLDER": { "type": "string", "description": "The placeholder when selecting person tags (unless separated)." },
+            "SEARCHABLE": { "type": "boolean", "description": "Whether the tag list can be searched by typing (unless separated)." },
+            "HIDE": { "type": "boolean", "description": "If true, hide the tags drop-down. Tags are still displayed on people." },
+            "SEPARATE": {
+              "type": "array",
+              "description": "An array of tag prefixes to separate into individual drop-downs.",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "PREFIX": { "type": "string" },
+                  "PLACEHOLDER": { "type": "string" },
+                  "SEARCHABLE": { "type": "boolean" },
+                  "HIDE": { "type": "boolean" }
+                }
+              }
+            }
+          }
+        },
+        "SEARCH": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "SHOW_SEARCH": { "type": "boolean", "description": "Set to false to hide the people search box." },
+            "SEARCH_LABEL": { "type": "string", "description": "Label for the people search box." }
+          }
+        },
+        "PERSON_HEADER": { "type": "string", "description": "Prefix shown before a participant's name on their individual page." },
+        "BIO": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "PURIFY_OPTIONS": {
+              "type": "object",
+              "description": "Additional options passed to DOMPurify when processing participant bios. For more details, see ITEM_DESCRIPTION.PURIFY_OPTIONS.",
+              "additionalProperties": true,
+              "properties": {
+                "FORBID_ATTR": { "type": "array", "items": { "type": "string" } }
+              }
+            }
+          }
+        }
+      }
+    },
+    "USELESS_CHECKBOX": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "CHECKBOX_LABEL": { "type": "string", "description": "Label for any \"useless\" placeholder checkboxes used for layout alignment." }
+      }
+    },
+    "INFORMATION": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "MARKDOWN_URL": { "type": "string", "description": "The address of the Markdown file containing additional information about the convention. May be a relative path to a file in the public directory." },
+        "LOADING_MESSAGE": { "type": "string", "description": "Text to show while the Markdown file is loading (usually never seen)." }
+      }
+    },
+    "SETTINGS": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Labels for the Settings page.",
+      "properties": {
+        "TITLE": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "LABEL": { "type": "string", "description": "Label for the settings page." }
+          }
+        },
+        "TIME_FORMAT": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "LABEL": { "type": "string", "description": "Label for the time format option group." },
+            "T12_HOUR_LABEL": { "type": "string", "description": "Label for the 12 hour option." },
+            "T24_HOUR_LABEL": { "type": "string", "description": "Label for the 24 hour option." }
+          }
+        },
+        "SHOW_LOCAL_TIME": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "LABEL": { "type": "string", "description": "Label for the Show Local Time option group." },
+            "NEVER_LABEL": { "type": "string", "description": "Label for the \"Never show\" option." },
+            "DIFFERS_LABEL": { "type": "string", "description": "Label for \"Display if different from convention timezone\"." },
+            "ALWAYS_LABEL": { "type": "string", "description": "Label for the \"Always display\" option." }
+          }
+        },
+        "SHOW_TIMEZONE": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "LABEL": { "type": "string", "description": "Label for the \"Show timezone after times\" option group." },
+            "NEVER_LABEL": { "type": "string", "description": "Label for the \"Never show\" option." },
+            "IF_LOCAL_LABEL": { "type": "string", "description": "Label for \"Show timezone if local time shown\"." },
+            "ALWAYS_LABEL": { "type": "string", "description": "Label for the \"Always show\" option." }
+          }
+        },
+        "SELECT_TIMEZONE": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "LABEL": { "type": "string", "description": "Label for the select-timezone group." },
+            "BROWSER_DEFAULT_LABEL": { "type": "string", "description": "Label to use the browser default timezone (will have the timezone name appended)." },
+            "SELECT_LABEL": { "type": "string", "description": "Label to select an explicit timezone." }
+          }
+        },
+        "DARK_MODE": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "LABEL": { "type": "string", "description": "Label for the dark mode settings group." },
+            "BROWSER_DEFAULT_LABEL": { "type": "string", "description": "Label for the default browser dark-mode preference option." },
+            "BROWSER_LIGHT_LABEL": { "type": "string", "description": "Label indicating the browser is currently in light mode." },
+            "BROWSER_DARK_LABEL": { "type": "string", "description": "Label indicating the browser is currently in dark mode." },
+            "LIGHT_MODE_LABEL": { "type": "string", "description": "Label for forcing light mode." },
+            "DARK_MODE_LABEL": { "type": "string", "description": "Label for forcing dark mode." }
+          }
+        }
+      }
+    },
+    "FOOTER": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "SITE_NOTE_MARKDOWN": { "type": "string", "description": "General note displayed in the footer of the page. May use Markdown for links, emphasis, etc." },
+        "COPYRIGHT_MARKDOWN": { "type": "string", "description": "Copyright notice, if required. May include Markdown." },
+        "CONCLAR_NOTE_MARKDOWN": { "type": "string", "description": "Note crediting ConClár. Free to remove or modify, but retaining it is politely requested to help promote this free tool." }
+      }
+    },
+    "TIMER": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "FETCH_INTERVAL_MINS": { "type": "number", "description": "Number of minutes between refreshes of program data." },
+        "TIMER_TICK_SECS": { "type": "number", "description": "Number of seconds between checks of the timer." }
+      }
+    },
+    "DEBUG_MODE": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ENABLE": { "type": "boolean", "description": "If true, display a banner showing online status, and allowing manual data fetch." },
+        "ONLINE_LABEL": { "type": "string", "description": "Label to display in debug mode when online." },
+        "OFFLINE_LABEL": { "type": "string", "description": "Label to display in debug mode when offline." },
+        "FETCH_BUTTON_LABEL": { "type": "string", "description": "Label to display in debug mode on the Fetch button." }
+      }
+    },
+    "SYNC": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Enables syncing programme selections across devices via a sync server. If omitted, or if API_URL is empty, sync is disabled entirely and everything else works as normal (selections stay in browser local storage / QR-code sharing only). The sync server API is documented in docs/sync_server_api.md.",
+      "properties": {
+        "API_URL": { "type": "string", "description": "The base URL of your sync server API, e.g. \"https://auth.example-con.org/api\". If omitted or empty, sync is disabled entirely." },
+        "LOADING_LABEL": { "type": "string", "description": "Label shown while the profile is being fetched on startup." },
+        "LOGIN_LABEL": { "type": "string", "description": "Label for the login link when the user is not authenticated." },
+        "LOGOUT_LABEL": { "type": "string", "description": "Label for the logout link. @display_name is replaced with the user's display name." },
+        "ERROR_LABEL": { "type": "string", "description": "Label for the error message when unable to connect to the sync server." },
+        "WARNING": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The popup shown the first time an unauthenticated user adds or removes a selection, prompting them to log in.",
+          "properties": {
+            "HEADING": { "type": "string", "description": "Heading of the sync warning popup." },
+            "TITLE": { "type": "string", "description": "Main message body of the sync warning popup." },
+            "DETAILS": { "type": "string", "description": "Expandable detail text shown when the user clicks \"More information\" in the sync warning popup." },
+            "DETAILS_LABEL": { "type": "string", "description": "Label for the button that expands the detail text in the sync warning popup." },
+            "LOGIN_LABEL": { "type": "string", "description": "Label for the primary login button in the sync warning popup." },
+            "DISMISS_LABEL": { "type": "string", "description": "Label for the dismiss link in the sync warning popup." }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -124,6 +124,7 @@
       "type": "object",
       "additionalProperties": false,
       "description": "Each value in this section sets the label that will appear on main navigation of the site. Useful for switching between different international spellings of \"programme\".",
+      "required": ["PROGRAM", "PEOPLE", "MYSCHEDULE", "SETTINGS"],
       "properties": {
         "PROGRAM": { "type": "string", "description": "Label for program/programme menu." },
         "PEOPLE": { "type": "string", "description": "Label for people menu." },
@@ -218,10 +219,12 @@
       "type": "object",
       "additionalProperties": false,
       "description": "General application-wide settings.",
+      "required": ["LOADING"],
       "properties": {
         "LOADING": {
           "type": "object",
           "additionalProperties": false,
+          "required": ["MESSAGE"],
           "properties": {
             "MESSAGE": { "type": "string", "description": "Message to display while loading." }
           }
@@ -232,11 +235,13 @@
       "type": "object",
       "additionalProperties": false,
       "description": "Settings for the main programme list, My Schedule, and shared-items pages.",
+      "required": ["LIMIT", "SEARCH", "MY_SCHEDULE", "SHARED"],
       "properties": {
         "LIMIT": {
           "type": "object",
           "additionalProperties": false,
           "description": "Controls the \"maximum items displayed\" drop-down on the programme page.",
+          "required": ["DEFAULT", "SHOW_MORE"],
           "properties": {
             "SHOW": { "type": "boolean", "description": "If true, \"limit number of items\" drop-down will be displayed." },
             "LABEL": { "type": "string", "description": "Label for limit drop-down." },
@@ -250,17 +255,27 @@
             "SHOW_MORE": {
               "type": "object",
               "additionalProperties": false,
+              "required": ["LABEL", "NO_MORE", "NUM_EXTRA"],
               "properties": {
                 "LABEL": { "type": "string", "description": "Label for the \"Show more\" button." },
                 "NO_MORE": { "type": "string", "description": "Message to display when no more items are available." },
                 "NUM_EXTRA": { "type": "integer", "description": "Number of items to add when \"Show more\" is pressed." }
               }
             }
+          },
+          "if": {
+            "required": ["SHOW"],
+            "properties": { "SHOW": { "const": true } }
+          },
+          "then": {
+            "required": ["OPTIONS", "ALL_LABEL", "LABEL"],
+            "properties": { "OPTIONS": true, "ALL_LABEL": true, "LABEL": true }
           }
         },
         "SEARCH": {
           "type": "object",
           "additionalProperties": false,
+          "required": ["SEARCH_LABEL"],
           "properties": {
             "SEARCH_LABEL": { "type": "string", "description": "Placeholder for the programme search box." }
           }
@@ -269,11 +284,13 @@
           "type": "object",
           "additionalProperties": false,
           "description": "Settings for the My Schedule page.",
+          "required": ["TITLE", "EMPTY", "INTRO", "SHARE"],
           "properties": {
             "TITLE": { "type": "string", "description": "Title of My Schedule page." },
             "EMPTY": {
               "type": "object",
               "additionalProperties": false,
+              "required": ["TEXT"],
               "properties": {
                 "TEXT": { "type": "string", "description": "Text to display on My Schedule when no programme items are selected." }
               }
@@ -283,6 +300,7 @@
               "type": "object",
               "additionalProperties": false,
               "description": "Settings for the QR code / link sharing section of My Schedule.",
+              "required": ["LABEL", "DESCRIPTION", "LINK_LABEL", "MAX_LENGTH", "MULTIPLE_DESCRIPTION", "MULTIPLE_LINK_LABEL"],
               "properties": {
                 "LABEL": { "type": "string", "description": "Heading for the shared link section on My Schedule." },
                 "DESCRIPTION": { "type": "string", "description": "Descriptive message for the link sharing section." },
@@ -298,6 +316,7 @@
           "type": "object",
           "additionalProperties": false,
           "description": "Settings for the page showing programme items shared via a link.",
+          "required": ["TITLE", "DESCRIPTION", "BUTTON_LABEL"],
           "properties": {
             "TITLE": { "type": "string", "description": "Title of the Shared Programme Items page." },
             "DESCRIPTION": { "type": "string", "description": "Descriptive text for the page showing shared items." },
@@ -346,6 +365,14 @@
             "PLACEHOLDER": { "type": "string", "description": "The placeholder for the \"day\" tags drop-down." },
             "SEARCHABLE": { "type": "boolean", "description": "Whether the day tag list can be searched by typing." },
             "HIDE": { "type": "boolean", "description": "If true, hide the day tags drop-down. Day tags are still shown on items if GENERATE is true." }
+          },
+          "if": {
+            "required": ["GENERATE"],
+            "properties": { "GENERATE": { "const": true } }
+          },
+          "then": {
+            "required": ["DAYS"],
+            "properties": { "DAYS": true }
           }
         },
         "DONTLIST": {
@@ -489,6 +516,14 @@
       "properties": {
         "SHOW_DURATION": { "type": "boolean", "description": "If true, minutes from program data will be displayed." },
         "DURATION_LABEL": { "type": "string", "description": "Format for duration. @mins is replaced by the number of minutes. Do not translate @mins." }
+      },
+      "if": {
+        "required": ["SHOW_DURATION"],
+        "properties": { "SHOW_DURATION": { "const": true } }
+      },
+      "then": {
+        "required": ["DURATION_LABEL"],
+        "properties": { "DURATION_LABEL": true }
       }
     },
     "START_TIME": {
@@ -598,6 +633,7 @@
     "INFORMATION": {
       "type": "object",
       "additionalProperties": false,
+      "required": ["MARKDOWN_URL"],
       "properties": {
         "MARKDOWN_URL": { "type": "string", "description": "The address of the Markdown file containing additional information about the convention. May be a relative path to a file in the public directory." },
         "LOADING_MESSAGE": { "type": "string", "description": "Text to show while the Markdown file is loading (usually never seen)." }
@@ -607,10 +643,12 @@
       "type": "object",
       "additionalProperties": false,
       "description": "Labels for the Settings page.",
+      "required": ["TITLE", "TIME_FORMAT", "SHOW_LOCAL_TIME", "SHOW_TIMEZONE", "SELECT_TIMEZONE", "DARK_MODE"],
       "properties": {
         "TITLE": {
           "type": "object",
           "additionalProperties": false,
+          "required": ["LABEL"],
           "properties": {
             "LABEL": { "type": "string", "description": "Label for the settings page." }
           }
@@ -618,6 +656,7 @@
         "TIME_FORMAT": {
           "type": "object",
           "additionalProperties": false,
+          "required": ["LABEL", "T12_HOUR_LABEL", "T24_HOUR_LABEL"],
           "properties": {
             "LABEL": { "type": "string", "description": "Label for the time format option group." },
             "T12_HOUR_LABEL": { "type": "string", "description": "Label for the 12 hour option." },
@@ -627,6 +666,7 @@
         "SHOW_LOCAL_TIME": {
           "type": "object",
           "additionalProperties": false,
+          "required": ["LABEL", "NEVER_LABEL", "DIFFERS_LABEL", "ALWAYS_LABEL"],
           "properties": {
             "LABEL": { "type": "string", "description": "Label for the Show Local Time option group." },
             "NEVER_LABEL": { "type": "string", "description": "Label for the \"Never show\" option." },
@@ -637,6 +677,7 @@
         "SHOW_TIMEZONE": {
           "type": "object",
           "additionalProperties": false,
+          "required": ["LABEL", "NEVER_LABEL", "IF_LOCAL_LABEL", "ALWAYS_LABEL"],
           "properties": {
             "LABEL": { "type": "string", "description": "Label for the \"Show timezone after times\" option group." },
             "NEVER_LABEL": { "type": "string", "description": "Label for the \"Never show\" option." },
@@ -647,6 +688,7 @@
         "SELECT_TIMEZONE": {
           "type": "object",
           "additionalProperties": false,
+          "required": ["LABEL", "BROWSER_DEFAULT_LABEL", "SELECT_LABEL"],
           "properties": {
             "LABEL": { "type": "string", "description": "Label for the select-timezone group." },
             "BROWSER_DEFAULT_LABEL": { "type": "string", "description": "Label to use the browser default timezone (will have the timezone name appended)." },
@@ -656,6 +698,7 @@
         "DARK_MODE": {
           "type": "object",
           "additionalProperties": false,
+          "required": ["LABEL", "BROWSER_DEFAULT_LABEL", "BROWSER_LIGHT_LABEL", "BROWSER_DARK_LABEL", "LIGHT_MODE_LABEL", "DARK_MODE_LABEL"],
           "properties": {
             "LABEL": { "type": "string", "description": "Label for the dark mode settings group." },
             "BROWSER_DEFAULT_LABEL": { "type": "string", "description": "Label for the default browser dark-mode preference option." },
@@ -679,6 +722,7 @@
     "TIMER": {
       "type": "object",
       "additionalProperties": false,
+      "required": ["FETCH_INTERVAL_MINS", "TIMER_TICK_SECS"],
       "properties": {
         "FETCH_INTERVAL_MINS": { "type": "number", "description": "Number of minutes between refreshes of program data." },
         "TIMER_TICK_SECS": { "type": "number", "description": "Number of seconds between checks of the timer." }
@@ -692,6 +736,14 @@
         "ONLINE_LABEL": { "type": "string", "description": "Label to display in debug mode when online." },
         "OFFLINE_LABEL": { "type": "string", "description": "Label to display in debug mode when offline." },
         "FETCH_BUTTON_LABEL": { "type": "string", "description": "Label to display in debug mode on the Fetch button." }
+      },
+      "if": {
+        "required": ["ENABLE"],
+        "properties": { "ENABLE": { "const": true } }
+      },
+      "then": {
+        "required": ["ONLINE_LABEL", "OFFLINE_LABEL", "FETCH_BUTTON_LABEL"],
+        "properties": { "ONLINE_LABEL": true, "OFFLINE_LABEL": true, "FETCH_BUTTON_LABEL": true }
       }
     },
     "SYNC": {
@@ -708,6 +760,7 @@
           "type": "object",
           "additionalProperties": false,
           "description": "The popup shown the first time an unauthenticated user adds or removes a selection, prompting them to log in.",
+          "required": ["HEADING", "TITLE", "DETAILS", "DETAILS_LABEL", "LOGIN_LABEL", "DISMISS_LABEL"],
           "properties": {
             "HEADING": { "type": "string", "description": "Heading of the sync warning popup." },
             "TITLE": { "type": "string", "description": "Main message body of the sync warning popup." },
@@ -717,6 +770,14 @@
             "DISMISS_LABEL": { "type": "string", "description": "Label for the dismiss link in the sync warning popup." }
           }
         }
+      },
+      "if": {
+        "required": ["API_URL"],
+        "properties": { "API_URL": { "type": "string", "minLength": 1 } }
+      },
+      "then": {
+        "required": ["WARNING"],
+        "properties": { "WARNING": true }
       }
     }
   }

--- a/src/utils/LocalTime.js
+++ b/src/utils/LocalTime.js
@@ -122,7 +122,7 @@ export class LocalTime {
 
   static getStoredTwelveHourTime() {
     const stored12HourTime = localStorage.getItem(this.twelveHourTimeClass);
-    if (configData.TIME_FORMAT.DEFAULT_12HR)
+    if (configData.TIME_FORMAT?.DEFAULT_12HR)
       // If defaulting to 12 hour, assume true unless "false" saved.
       return stored12HourTime === "false" ? false : true;
     // If defaulting to 24 hour, assume false unless "true" saved.
@@ -248,18 +248,18 @@ export class LocalTime {
     function format12HourTime(dateAndTime) {
       if (dateAndTime.hour === 0)
         return `12:${formatTwoDigits(dateAndTime.minute)} ${
-          configData.TIME_FORMAT.AM
+          configData.TIME_FORMAT?.AM ?? "AM"
         }`;
       if (dateAndTime.hour < 12)
         return `${dateAndTime.hour}:${formatTwoDigits(dateAndTime.minute)} ${
-          configData.TIME_FORMAT.AM
+          configData.TIME_FORMAT?.AM ?? "AM"
         }`;
       if (dateAndTime.hour === 12)
         return `12:${formatTwoDigits(dateAndTime.minute)} ${
-          configData.TIME_FORMAT.PM
+          configData.TIME_FORMAT?.PM ?? "PM"
         }`;
       return `${dateAndTime.hour - 12}:${formatTwoDigits(dateAndTime.minute)} ${
-        configData.TIME_FORMAT.PM
+        configData.TIME_FORMAT?.PM ?? "PM"
       }`;
     }
     //let language = window.navigator.userLanguage || window.navigator.language;
@@ -351,10 +351,12 @@ export class LocalTime {
     // Compare the dates without time to see if we're showing time on next or previous day, and if so attach label.
     switch (Temporal.PlainDate.compare(localDate, conDate)) {
       case -1:
-        cacheValue[cacheKey] = formattedTime + configData.LOCAL_TIME.PREV_DAY;
+        cacheValue[cacheKey] =
+          formattedTime + (configData.LOCAL_TIME?.PREV_DAY ?? "");
         break;
       case 1:
-        cacheValue[cacheKey] = formattedTime + configData.LOCAL_TIME.NEXT_DAY;
+        cacheValue[cacheKey] =
+          formattedTime + (configData.LOCAL_TIME?.NEXT_DAY ?? "");
         break;
       default:
         cacheValue[cacheKey] = formattedTime;
@@ -403,23 +405,22 @@ export class LocalTime {
    * @returns {Array}
    */
   static filterPastItems(program) {
-    if (configData.SHOW_PAST_ITEMS.FROM_START) {
+    const adjustMinutes = configData.SHOW_PAST_ITEMS?.ADJUST_MINUTES ?? 0;
+    if (configData.SHOW_PAST_ITEMS?.FROM_START) {
       // Filter by past item state.  Quick hack to treat this as a filter.
       const cutOff = Temporal.Now.zonedDateTimeISO("UTC").add({
-        minutes: configData.SHOW_PAST_ITEMS.ADJUST_MINUTES,
+        minutes: adjustMinutes,
       });
       return program.filter((item) => {
         return Temporal.ZonedDateTime.compare(cutOff, item.startDateAndTime) <= 0;
       });
     } else {
       const cutOff = Temporal.Now.zonedDateTimeISO("UTC").subtract({
-        minutes: configData.SHOW_PAST_ITEMS.ADJUST_MINUTES,
+        minutes: adjustMinutes,
       });
       return program.filter((item) => {
         const itemNearEndTime = item.startDateAndTime.add({
-          minutes: item.hasOwnProperty("mins")
-            ? item.mins
-            : configData.SHOW_PAST_ITEMS.ADJUST_MINUTES,
+          minutes: item.hasOwnProperty("mins") ? item.mins : adjustMinutes,
         });
         return Temporal.ZonedDateTime.compare(cutOff, itemNearEndTime) <= 0;
       });

--- a/src/validateConfig.js
+++ b/src/validateConfig.js
@@ -1,3 +1,15 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import Ajv2020 from "ajv/dist/2020.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const schema = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "configSchema.json"), "utf-8")
+);
+const ajv = new Ajv2020({ allErrors: true, strict: true });
+const validateSchema = ajv.compile(schema);
+
 /**
  * Validate config.json
  *
@@ -11,8 +23,14 @@
  */
 export function validateConfig(configData) {
   const errors = [];
-  validateDataSourceConfig(configData, errors);
-  validateVenuesConfig(configData, errors);
+  validateConfigSchema(configData, errors);
+  try {
+    validateDataSourceConfig(configData, errors);
+    validateVenuesConfig(configData, errors);
+  } catch {
+    // configData didn't match the expected shape closely enough for these
+    // checks to run; the schema errors above already explain why.
+  }
   if (errors.length > 0) {
     throw new Error(
       "Invalid config.json:\n - " + errors.join("\n - ")
@@ -21,9 +39,43 @@ export function validateConfig(configData) {
 }
 
 /**
- * Validate that DATA_URLS and the legacy PROGRAM_DATA_URL/PEOPLE_DATA_URL
- * keys aren't ambiguously combined, and that DATA_URLS itself specifies
- * exactly one of COMBINED or the SCHEDULE+PEOPLE pair.
+ * Validate configData against configSchema.json, converting ajv's errors
+ * into the same dotted/bracket path style used by the hand-written checks
+ * below (e.g. VENUES.MAPPING[0].NAME).
+ *
+ * @param {object} configData Parsed contents of config.json.
+ * @param {string[]} errors Accumulator for problem descriptions.
+ */
+function validateConfigSchema(configData, errors) {
+  if (!validateSchema(configData)) {
+    for (const err of validateSchema.errors) {
+      errors.push(formatAjvError(err));
+    }
+  }
+}
+
+/**
+ * @param {import("ajv").ErrorObject} err
+ * @returns {string}
+ */
+function formatAjvError(err) {
+  const path = err.instancePath
+    .replace(/^\//, "")
+    .replace(/\//g, ".")
+    .replace(/\.(\d+)/g, "[$1]");
+  const prefix = path ? `${path} ` : "config ";
+  if (err.keyword === "additionalProperties") {
+    const badKey = err.params.additionalProperty;
+    const location = path ? `${path}.${badKey}` : badKey;
+    return `${location} is not a recognized config key.`;
+  }
+  return `${prefix}${err.message}`;
+}
+
+/**
+ * Validate that exactly one of DATA_URLS or the legacy
+ * PROGRAM_DATA_URL/PEOPLE_DATA_URL pair is given, and that DATA_URLS itself
+ * specifies exactly one of COMBINED or the SCHEDULE+PEOPLE pair.
  *
  * @param {object} configData Parsed contents of config.json.
  * @param {string[]} errors Accumulator for problem descriptions.
@@ -37,6 +89,10 @@ function validateDataSourceConfig(configData, errors) {
   if (hasLegacyUrls && hasDataUrls) {
     errors.push(
       "config.json cannot specify both DATA_URLS and PROGRAM_DATA_URL/PEOPLE_DATA_URL."
+    );
+  } else if (!hasLegacyUrls && !hasDataUrls) {
+    errors.push(
+      "config.json must specify either DATA_URLS or PROGRAM_DATA_URL/PEOPLE_DATA_URL."
     );
   }
 


### PR DESCRIPTION
## Problem

Currently the configuration is stored in `src/config.json`, and described by entries in `README.md`.

Unfortunately, there is no automated way to validate the config against the README documentation, and there are both settings with missing and incorrect (e.g. README says `CALENDARLINK.CALENDARLINK`, but the actual setting is `CALENDARLINK.TITLE`).

There is also a problem that missing settings are difficult to identify and correct, and can cause the site to fail when the missing setting is encountered in the code, rather than at startup.

## Proposed solution

Remove the configuration documentation from the README. Maintain a new `configSchema.json` as the single source of truth.

This allows us to:
- Automatically generate a new documentation page, `docs/config_reference.md` by running `npm run docs:generate`, that is automatically generated from the schema.
- Validate `config.json` against the schema when `npm start` or `npm run build` start up. This ensures that the site builds with a valid schema.
- Validate `config_example.json` as as a GitHub action on PRs.
- Validate the documentation page as a GitHub action. This generates an in-memory version of the document, compares it to the version in the repo, and if they don't match, it fails.

Note: I did look at regenerating the documentation during check-in. However, this would have had permission problems, and I don't think it would be allowed from forks. Providing a command to rebuild and validation seems an acceptable compromise.

One issue I considered was settings that have been "optional". I have made settings that form core functionality required, and others optional. I've looked at where optional settings are used, and tried to make sure that sensible defaults/fallbacks are provided.