### PR TITLE
Add Weights to Tags to enable custom ordering

### DIFF
--- a/docs/config_reference.md
+++ b/docs/config_reference.md
@@ -95,6 +95,9 @@ Copy `src/config_example.json` to `src/config.json` and customise. See the [Gett
 - `TAGS.SEPARATE[].PLACEHOLDER` (string) — Placeholder for this drop-down.
 - `TAGS.SEPARATE[].SEARCHABLE` (boolean) — Whether this drop-down can be searched by typing.
 - `TAGS.SEPARATE[].HIDE` (boolean) — If true, hide this drop-down. Tags are still displayed on items.
+- `TAGS.WEIGHTS` (array of object) — An array of weights to control the sort order of tags within drop-downs. Negative weights float to the top, positive weights sink to the bottom. Tags without a weight default to 0. Tags with the same weight are sorted alphabetically.
+- `TAGS.WEIGHTS[].VALUE` (string) — The tag value to set the weight for.
+- `TAGS.WEIGHTS[].WEIGHT` (number) — The numeric weight of the tag.
 - `TAGS.FORMAT_AS_TAG` (boolean) — If set to true, turns Grenadine item format into a KonOpas-style "type" tag.
 - `TAGS.DAY_TAG` (object) — Settings for auto-generated per-day tags.
 - `TAGS.DAY_TAG.GENERATE` (boolean) — If set to true, will generate tags for each day of the convention.
@@ -176,6 +179,9 @@ Copy `src/config_example.json` to `src/config.json` and customise. See the [Gett
 - `PEOPLE.TAGS.SEPARATE[].PLACEHOLDER` (string)
 - `PEOPLE.TAGS.SEPARATE[].SEARCHABLE` (boolean)
 - `PEOPLE.TAGS.SEPARATE[].HIDE` (boolean)
+- `PEOPLE.TAGS.WEIGHTS` (array of object) — An array of weights to control the sort order of tags within drop-downs. Negative weights float to the top, positive weights sink to the bottom. Tags without a weight default to 0. Tags with the same weight are sorted alphabetically.
+- `PEOPLE.TAGS.WEIGHTS[].VALUE` (string) — The tag value to set the weight for.
+- `PEOPLE.TAGS.WEIGHTS[].WEIGHT` (number) — The numeric weight of the tag.
 - `PEOPLE.SEARCH` (object)
 - `PEOPLE.SEARCH.SHOW_SEARCH` (boolean) — Set to false to hide the people search box.
 - `PEOPLE.SEARCH.SEARCH_LABEL` (string) — Label for the people search box.

--- a/src/ProgramData.js
+++ b/src/ProgramData.js
@@ -242,6 +242,26 @@ export class ProgramData {
     }
 
     /**
+     * Takes a tag and finds its weight. Tags will default to 0, so negative
+     * numbers will float to top of list, positive will fall to bottom.
+     * @param {*} tag
+     * @returns int
+     */
+    function tagWeight(tag, lookupValue) {
+      // If tag has explicit weight, use that.
+      if (tag.hasOwnProperty("weight"))
+        return tag.weight;
+      else if (tagConfig.hasOwnProperty("WEIGHTS")) {
+        // If WEIGHTS section exists, search for the tag value.
+        const weight = tagConfig.WEIGHTS.find((item) => item.VALUE === lookupValue);
+        if (weight && weight.hasOwnProperty("WEIGHT"))
+          return weight.WEIGHT;
+      }
+      // Default tag to 0.
+      return 0;
+    }
+
+    /**
      * Takes a tag string and decodes into a tag object. Adds to tags.all array.
      * @param {*} tag
      * @returns

--- a/src/ProgramData.js
+++ b/src/ProgramData.js
@@ -276,24 +276,28 @@ export class ProgramData {
       if (hasProps) {
         if (tag.hasOwnProperty("label")) newTag.label = tag.label;
         if (tag.hasOwnProperty("category")) newTag.category = tag.category;
+        newTag.weight = tagWeight(tag, newTag.value);
         tags.all[value] = newTag;
         return newTag;
       }
       // If we get here, it's an old style tag.
+      const PREFIX_INDEX = 1;
+      const LABEL_INDEX = 2;
       const matches = tag.match(/^(.+):(.+)/);
-      if (matches && matches.length === 3) {
-        const prefix = matches[1];
-        const label = matches[2];
+      const hasPrefix = matches && matches.length === 3;
+      const lookupValue = hasPrefix ? matches[LABEL_INDEX] : tag;
+      if (hasPrefix) {
         // Tag has a prefix. Check if it's one we're interested in.
-        if (prefix in tags) {
-          newTag.category = prefix;
-          newTag.label = Format.formatTag(label);
+        if (matches[PREFIX_INDEX] in tags) {
+          newTag.category = matches[PREFIX_INDEX];
+          newTag.label = Format.formatTag(matches[LABEL_INDEX]);
         } else {
           newTag.label = tag;
         }
       } else {
         newTag.label = tag;
       }
+      newTag.weight = tagWeight(tag, lookupValue);
       tags.all[value] = newTag;
       return newTag;
     }

--- a/src/configSchema.json
+++ b/src/configSchema.json
@@ -347,6 +347,19 @@
             }
           }
         },
+        "WEIGHTS": {
+          "type": "array",
+          "description": "An array of weights to control the sort order of tags within drop-downs. Negative weights float to the top, positive weights sink to the bottom. Tags without a weight default to 0. Tags with the same weight are sorted alphabetically.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["VALUE", "WEIGHT"],
+            "properties": {
+              "VALUE": { "type": "string", "description": "The tag value to set the weight for." },
+              "WEIGHT": { "type": "number", "description": "The numeric weight of the tag." }
+            }
+          }
+        },
         "FORMAT_AS_TAG": { "type": "boolean", "description": "If set to true, turns Grenadine item format into a KonOpas-style \"type\" tag." },
         "DAY_TAG": {
           "type": "object",
@@ -593,6 +606,19 @@
                   "PLACEHOLDER": { "type": "string" },
                   "SEARCHABLE": { "type": "boolean" },
                   "HIDE": { "type": "boolean" }
+                }
+              }
+            },
+            "WEIGHTS": {
+              "type": "array",
+              "description": "An array of weights to control the sort order of tags within drop-downs. Negative weights float to the top, positive weights sink to the bottom. Tags without a weight default to 0. Tags with the same weight are sorted alphabetically.",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["VALUE", "WEIGHT"],
+                "properties": {
+                  "VALUE": { "type": "string", "description": "The tag value to set the weight for." },
+                  "WEIGHT": { "type": "number", "description": "The numeric weight of the tag." }
                 }
               }
             }

--- a/src/config_example.json
+++ b/src/config_example.json
@@ -105,6 +105,9 @@
       { "PREFIX": "Tag", "PLACEHOLDER": "Select tag", "SEARCHABLE": false, "HIDE": false },
       { "PREFIX": "Track", "PLACEHOLDER": "Select track", "SEARCHABLE": false, "HIDE": false }
     ],
+    "WEIGHTS": [
+      { "VALUE": "sessioon_requires_signup", "WEIGHT": -1 }
+    ],
     "FORMAT_AS_TAG": false,
     "DAY_TAG": {
       "GENERATE": true,


### PR DESCRIPTION
This change adds "weight" to tags, that will be used in ordering:

- Tags with equal weights will be sorted alphabetically.
- If "new style" tag in source file, allows `weight` to be specified as a property of tag in file.
- Default weight for each tag can be set in config in `TAGS.WEIGHTS[]`, with each element having the format: `{ "VALUE": "session_streamed", "WEIGHT": -5 }`.
- Any tags not set in schedule file or config will default to "0".
- Negative weight values will force items to the top of the list, positive will drop them to the bottom.
- Tag categories that wish to remain alphabetic don't need any changes - they will default to weights of "0", and as all tags have the same weight, they will fall back to alphabetic order.
- People tags also support the same weights.
